### PR TITLE
FOSDEM 2024 Scott Chacon git aliases

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -29,7 +29,9 @@
 	lola = log --graph --decorate --oneline --all --abbrev-commit
 	logg = log --graph --decorate --all
 	blog = log origin/master... --left-right
+	credit = blame -w -C -C -C
 	ds = diff --staged
+	dw = diff --word-diff
 	ls = ls-files
 	l  = log --pretty=oneline --abbrev-commit
 	fixup = commit --fixup

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -106,3 +106,5 @@
 	plus-emph-style = "#9fca56" bold "#295738"
 	plus-style = syntax "#123730"
 	keep-plus-minus-markers = true
+[maintenance]
+	repo = {{ .chezmoi.homeDir }}/.local/share/chezmoi

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -108,3 +108,5 @@
 	keep-plus-minus-markers = true
 [maintenance]
 	repo = {{ .chezmoi.homeDir }}/.local/share/chezmoi
+[fetch]
+	writeCommitGraph = true

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -29,7 +29,7 @@
 	lola = log --graph --decorate --oneline --all --abbrev-commit
 	logg = log --graph --decorate --all
 	blog = log origin/master... --left-right
-	credit = blame -w -C -C -C
+	credit = blame --color-lines -w -C -C -C
 	ds = diff --staged
 	dw = diff --word-diff
 	ls = ls-files

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -49,6 +49,7 @@
 	whitespace = nowarn
 [branch]
 	autosetupmerge = true
+	sort = -committerdate
 [rebase]
 	autosquash = true
 {{- if eq .chezmoi.os "darwin" }}


### PR DESCRIPTION
- `git credit`: `git blame` + ignore whitespace, and follow moved code blocks across files & commits
  - I renamed this to `credit`, as it follows further than a simple `git blame`.
  - Can find who should get credit for introducing code blocks, looking past simple refactors & reorganizations.
  - Using "positive language" as inspired by [this post][1]
  - I also added `--color-lines` because this makes it easier to see which blocks are part of the same commit
- `git dw`: Git `--word-diff`
- Settings:
  - Sort `git branch` output by reverse committer date (most recent first, oldest last)
  - Write commit graph data on `fetch`.  This speeds up the first call to `git log --graph` because the work was already done during `fetch`.
  - Enable maintenance tasks with incremental strategy (default) for this `chezmoi` repo.
    - Start this on a system with `git maintenance start` (uses either `crontab` or SystemD timers + user units)


[1]: https://dev.to/damcosset/git-blame-should-be-called-git-credit-27h5