### PR TITLE
.config/gh: Fix OAuth token data schema on non-macOS

### DIFF
--- a/dot_config/gh/hosts.yml.tmpl
+++ b/dot_config/gh/hosts.yml.tmpl
@@ -1,13 +1,16 @@
 github.com:
     user: {{ .githubuser }}
     git_protocol: ssh
-    users:
 {{- if lookPath "lpass" -}}
 {{- $lpResults := ( printf "GitHub: gh - GitHub token - %s" .chezmoi.hostname | lastpass) -}}
 {{-   if $lpResults }}{{ $lpItem := index $lpResults 0 }}
+{{-     if ne .chezmoi.os "darwin" | and $lpItem }}
+    oauth_token: {{ $lpItem.note.clientsecret | trim }}
+{{-     end }}
+    users:
         # {{ $lpItem.note.name | trim }}
         # CREATED: {{ $lpItem.note.creationDate | trim | toDate "January,02,2006" | date "2006-01-02" }}
         {{ .githubuser }}: {{ if eq .chezmoi.os "darwin" | or (not $lpItem) }}{}{{ else }}
-            oauth_token: {{ $lpItem.note.clientsecret }}{{ end }}
+            oauth_token: {{ $lpItem.note.clientsecret | trim }}{{ end }}
 {{-   end -}}
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
Apparently the duplication in this config file is necessary :shrug: 