### PR TITLE
.config/sway: Add wl-color-picker binding

### DIFF
--- a/dot_config/sway/definitions.d/02-wl-color-picker.conf
+++ b/dot_config/sway/definitions.d/02-wl-color-picker.conf
@@ -1,0 +1,1 @@
+bindsym $mod+Shift+i exec wl-color-picker


### PR DESCRIPTION
Note: Depends on unbind `$mod+Shift+i` in:

    ~/.config/sway/config.d/01-override-inhibit-idle.conf