### PR TITLE
omit yay fzf if not installed

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -41,6 +41,11 @@
 {{-   $launchpaduser = promptString "launchpaduser" -}}
 {{- end -}}
 
+{{- $osIdLike := .chezmoi.os -}}
+{{- if hasKey .chezmoi.osRelease "idLike" -}}
+{{-   $osIdLike = printf "%s-%s" .chezmoi.os .chezmoi.osRelease.idLike -}}
+{{- end -}}
+
 {{- $xdg_session_type := "" -}}
 {{- if hasKey . "xdg_session_type" -}}
 {{-   $xdg_session_type = .xdg_session_type -}}
@@ -62,5 +67,6 @@ data:
   githubuser: "{{ $githubuser }}"
   launchpaduser: "{{ $launchpaduser }}"
   # platform-specific vars
+  osFamily: {{ $osIdLike | quote }}
   xdg_session_type: "{{ $xdg_session_type }}"
 

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -62,6 +62,9 @@ README.md
 .local/share/sway/scripts/irssi-fnotify-local.sh
 {{   end -}}
 {{ end -}}
+{{ if not (lookPath "fzf") -}}
+.config/zsh/config.d/*-fzf*.zsh
+{{ end -}}
 {{ if not (lookPath "mpv") -}}
 .config/mpv
 {{ end -}}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -78,3 +78,6 @@ README.md
 # Don't install SystemD units
 .config/systemd
 {{ end -}}
+{{ if not (eq .chezmoi.os "linux") | and (hasKey .chezmoi.osRelease "idLike" | and (not (eq (index .chezmoi.osRelease "idLike") "arch"))) | or (not (lookPath "yay")) -}}
+.config/zsh/config.d/03-yay-fzf-search.zsh
+{{ end -}}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -78,6 +78,6 @@ README.md
 # Don't install SystemD units
 .config/systemd
 {{ end -}}
-{{ if not (eq .chezmoi.os "linux") | and (hasKey .chezmoi.osRelease "idLike" | and (not (eq (index .chezmoi.osRelease "idLike") "arch"))) | or (not (lookPath "yay")) -}}
+{{ if not (eq .osFamily "linux-arch") | or (not (lookPath "yay")) -}}
 .config/zsh/config.d/03-yay-fzf-search.zsh
 {{ end -}}


### PR DESCRIPTION
- **.chezmoiignore: Omit zsh yay-fzf fxns (non-Arch-like distros or not installed)**
- **.chezmoiignore, .chezmoi.yaml.tmpl: Simplify .osRelease.idLike logic into .osFamily**
