### PR TITLE
git fzf fix os specific copy cmd

### DIFF
--- a/dot_config/zsh/config.d/git-fzf.zsh
+++ b/dot_config/zsh/config.d/git-fzf.zsh
@@ -17,12 +17,12 @@
 
 alias glNoGraph='git log --color=always --format="%C(auto)%h%d %s %C(brightblack)%C(bold)%cr% C(auto)%an %G?" "$@"'
 
-_gitLogLineToHash="echo {} | grep -o '[a-f0-9]\{7\}' | head -1"
+_gitLogLineToHash="echo {} | grep -o '[a-f0-9]\{7\}' | head -1 | tr -d '\n'"
 _viewGitLogLine="$_gitLogLineToHash | xargs -I % sh -c 'git show --color=always --show-signature % | delta'"
 _viewGitLogLineUnfancy="$_gitLogLineToHash | xargs -I % sh -c 'git show %'"
 
-unameOut="$(uname -s)"
-case "${unameOut}" in
+_unameOS="$(uname -s)"
+case "${_unameOS}" in
     Linux*)     if command -v wayland-scanner && [[ "$XDG_SESSION_TYPE" == *wayland* ]]; then
                   _clipboardCopyCmd="wl-copy"
                 elif [[ "$XDG_SESSION_TYPE" == ** ]]; then
@@ -90,7 +90,7 @@ gls() {
             --header "enter to view, alt-y to copy hash, alt-v to open in vim" \
             --bind "enter:execute:$_viewGitLogLine   | less -R" \
             --bind "alt-v:execute:$_viewGitLogLineUnfancy | vim -" \
-            --bind "alt-y:execute:$_gitLogLineToHash | wl-copy" \
+            --bind "alt-y:execute:$_gitLogLineToHash | ${_clipboardCopyCmd}" \
             --prompt ' > ' \
             --bind 'ctrl-/:+change-preview-window(70%|99%|hidden|)' \
             --bind 'ctrl-/:+refresh-preview' \

--- a/dot_config/zsh/config.d/git-fzf.zsh
+++ b/dot_config/zsh/config.d/git-fzf.zsh
@@ -21,6 +21,22 @@ _gitLogLineToHash="echo {} | grep -o '[a-f0-9]\{7\}' | head -1"
 _viewGitLogLine="$_gitLogLineToHash | xargs -I % sh -c 'git show --color=always --show-signature % | delta'"
 _viewGitLogLineUnfancy="$_gitLogLineToHash | xargs -I % sh -c 'git show %'"
 
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     if command -v wayland-scanner && [[ "$XDG_SESSION_TYPE" == *wayland* ]]; then
+                  _clipboardCopyCmd="wl-copy"
+                elif [[ "$XDG_SESSION_TYPE" == ** ]]; then
+                  _clipboardCopyCmd="xclip -selection clipboard -in"
+                fi;;
+    Darwin*)    _clipboardCopyCmd="pbcopy";;
+    CYGWIN*)    ;& # fall-through
+    MINGW*)     ;& # fall-through
+    MSYS_NT*)   _clipboardCopyCmd="perl -pe 'chomp if eof' | clip.exe";;
+    *)          # unknown OS... assume other Unix + Xorg
+                _clipboardCopyCmd="xclip -selection clipboard -in"
+                ;;
+esac
+
 # ANSI Colors
 c_reset='\033[0m'
 c_black='\033[0;30m'


### PR DESCRIPTION
- **.config/zsh/config.d/git-fzf.zsh: Handle OS-specific clipboard copy commands**
- **.config/zsh/config.d/git-fzf.zsh: Trim trailing newlines in _gitLogLineToHash**
