### PR TITLE
fix linux ttyS0 cisco switch vt100 screen config

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -25,6 +25,7 @@ README.md
 {{ if not (eq .chezmoi.os "darwin") -}}
 .config/profile.d/01-osx-manpath.sh
 .config/profile.d/01-osx-sbin-path.sh
+.config/profile.d/02-osx-gnu-screen-debug-path.sh
 {{ else if not (eq .chezmoi.os "linux") -}}
 .config/profile.d/00-xdg-terminal-command.sh
 {{ end -}}

--- a/dot_config/profile.d/executable_02-osx-gnu-screen-debug-path.sh
+++ b/dot_config/profile.d/executable_02-osx-gnu-screen-debug-path.sh
@@ -1,0 +1,7 @@
+if [ -e "/opt/gnu-screen-debug/bin" ]; then
+  case ":${PATH}:" in
+    *:"/opt/gnu-screen-debug/bin":*) : ;; # no-op
+    *) export PATH="/opt/gnu-screen-debug/bin:$PATH" ;;
+  esac
+fi
+

--- a/dot_config/screen/screenrc.cisco-vt100
+++ b/dot_config/screen/screenrc.cisco-vt100
@@ -1,0 +1,27 @@
+# reset escape key to the default
+#escape ^Aa
+
+# Reset to Ctrl-B + b
+escape ^Bb
+
+# Increase default scrollback history buffer
+defscrollback 100000
+
+# Fix xterm scrolling when alt text buffer is selected
+# From https://web.archive.org/web/20190411015146/http://www4.cs.fau.de/~jnweiger/screen-faq.html
+termcapinfo xterm ti@:te@
+
+## Cisco Switch vt100 settings
+# Fix backspace on macOS + Cisco
+bindkey -d "\177" stuff ^H
+
+# fix delete key
+# From: https://web.archive.org/web/20240924210959/https://lists.gnu.org/archive/html/screen-users/2020-08/msg00012.html
+bindkey -k kD     stuff "^?"
+bindkey "\033[3~" stuff "^?"
+
+# Fix Home / End keys
+# From: https://unix.stackexchange.com/a/465362/7688
+# See: man terminfo
+markkeys "$=\205"
+markkeys "0=\201"

--- a/dot_config/zsh/config.d/alias.non-skel.local.zsh
+++ b/dot_config/zsh/config.d/alias.non-skel.local.zsh
@@ -61,3 +61,6 @@ alias ff="fzf -m --preview \
 #preview-border:#2eb398 #Matcha Bright Teal
 #preview-border:#3b758c #Matcha Dim Teal
 # preview-label:#45ff82 #Matcha Bright Mint Green
+
+# Cisco vt100 screenrc RS-232 serial console
+alias cisco-console='screen -c ~/.config/screen/screenrc.cisco-vt100 $@'

--- a/dot_screenrc
+++ b/dot_screenrc
@@ -10,13 +10,14 @@ defscrollback 100000
 # Fix xterm scrolling when alt text buffer is selected
 # From https://web.archive.org/web/20190411015146/http://www4.cs.fau.de/~jnweiger/screen-faq.html
 termcapinfo xterm ti@:te@
-# Fix backspace on macOS
-bindkey -d "\177" stuff ^H
 
+## Cisco Switch vt100 settings
+# Fix backspace on macOS + Cisco
+#bindkey -d "\177" stuff ^H
 # fix delete key
 # From: https://web.archive.org/web/20240924210959/https://lists.gnu.org/archive/html/screen-users/2020-08/msg00012.html
-bindkey -k kD     stuff "^?"
-bindkey "\033[3~" stuff "^?"
+#bindkey -k kD     stuff "^?"
+#bindkey "\033[3~" stuff "^?"
 
 # Fix Home / End keys
 # From: https://unix.stackexchange.com/a/465362/7688


### PR DESCRIPTION
- **.screenrc: Comment out Cisco vt100 related settings**
- **.config/screen/screenrc.cisco-vt100: Add Cisco vt100 specific config for GNU screen**
- **.config/{zsh,profile.d}: Add cisco-console alias & GNU screen debug bin to PATH (if exists)**
- **.config/profile.d: Omit 02-osx-gnu-screen-debug-path.sh on non-macOS**
