### PR TITLE
lyra monterey homebrew freeze

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -26,6 +26,9 @@ README.md
 .config/profile.d/01-osx-manpath.sh
 .config/profile.d/01-osx-sbin-path.sh
 .config/profile.d/02-osx-gnu-screen-debug-path.sh
+{{   if not (eq .chezmoi.hostname "lyra") -}}
+.config/profile.d/02-osx-monterey-homebrew-freeze.sh
+{{   end -}}
 {{ else if not (eq .chezmoi.os "linux") -}}
 .config/profile.d/00-xdg-terminal-command.sh
 {{ end -}}

--- a/dot_config/profile.d/executable_02-osx-monterey-homebrew-freeze.sh
+++ b/dot_config/profile.d/executable_02-osx-monterey-homebrew-freeze.sh
@@ -1,0 +1,4 @@
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+export HOMEBREW_NO_CLEANUP_FORMULAE=llvm,terraform,opentofu,ansible,openssl
+export HOMEBREW_NO_INSTALL_FROM_API=1


### PR DESCRIPTION
- **.config/profile.d: Set Homebrew env vars to lock auto-update, no cleanup & repo-based installs only**
- **.chezmoiignore: Omit Monterey Homebrew Freeze profile.d vars except on lyra host**
