### PR TITLE
.config/ripgrep: Add some ArchLinux maintainer filetype patterns

### DIFF
--- a/dot_config/ripgrep/rgrc.conf
+++ b/dot_config/ripgrep/rgrc.conf
@@ -45,3 +45,5 @@
 --type-add=sway:scratchpad
 --type-add=sway:screenshot
 --type-add=sway:shutdown
+--type-add=hook:*.hook
+--type-add=pkgbuild:PKGBUILD


### PR DESCRIPTION
- `hook`: `*.hook`
- `pkgbuild`: `PKGBUILD`