### PR TITLE
.chezmoiignore: Omit swaylock configs if not installed

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -91,6 +91,9 @@ README.md
 .config/sway/definitions.d/08-irssi-fnotify.conf
 .local/share/sway/scripts/irssi-fnotify-local.sh
 {{   end -}}
+{{   if not (lookPath "swaylock") -}}
+.config/swaylock
+{{   end -}}
 {{ end -}}
 {{ if not (lookPath "fzf") -}}
 .config/zsh/config.d/*-fzf*.zsh


### PR DESCRIPTION
- **[.chezmoiignore: Omit swaylock configs if not installed](https://github.com/trinitronx/dotfiles/pull/84/commits/42c93a93a223569e5ef8345ab2b4a2e308b3f4f0)**