### PR TITLE
.config/waybar: Avoid mirrored piKVM waybar draw overlap

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -4,7 +4,7 @@
     "ipc": true,
     "include": [
         "/usr/share/sway/templates/waybar/config.jsonc",
-        "$HOME/.config/waybar/config.modes.jsonc",
+        "$XDG_CONFIG_HOME/waybar/config.modes.jsonc",
         "$XDG_CONFIG_HOME/waybar/config.pikvm-mirroring.jsonc"
     ],
     "start_hidden": true,
@@ -16,8 +16,8 @@
     "name": "bar-1",
     "ipc": true,
     "include": [
-        "$HOME/.config/waybar/config.d/*.jsonc",
-        "$HOME/.config/waybar/config.modes.jsonc",
+        "$XDG_CONFIG_HOME/waybar/config.d/*.jsonc",
+        "$XDG_CONFIG_HOME/waybar/config.modes.jsonc",
         "$XDG_CONFIG_HOME/waybar/config.pikvm-mirroring.jsonc"
     ],
     "start_hidden": true,

--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -4,12 +4,12 @@
     "ipc": true,
     "include": [
         "/usr/share/sway/templates/waybar/config.jsonc",
-        "$HOME/.config/waybar/config.modes.jsonc"
+        "$HOME/.config/waybar/config.modes.jsonc",
+        "$XDG_CONFIG_HOME/waybar/config.pikvm-mirroring.jsonc"
     ],
     "start_hidden": true,
     "mode": "hide",
     "modifier-reset": "release"
-
 },
 {
     "id": "bar-1",
@@ -17,7 +17,8 @@
     "ipc": true,
     "include": [
         "$HOME/.config/waybar/config.d/*.jsonc",
-        "$HOME/.config/waybar/config.modes.jsonc"
+        "$HOME/.config/waybar/config.modes.jsonc",
+        "$XDG_CONFIG_HOME/waybar/config.pikvm-mirroring.jsonc"
     ],
     "start_hidden": true,
     "mode": "hide",

--- a/dot_config/waybar/config.pikvm-mirroring.jsonc
+++ b/dot_config/waybar/config.pikvm-mirroring.jsonc
@@ -1,0 +1,6 @@
+{
+    "output": [
+        "!The Linux Foundation PiKVM V4 Plus CAFEBABE",
+        "*"
+    ]
+}


### PR DESCRIPTION
Notes:

 - Waybar by default draws a bar for each output
 - Duplicate bars were drawn when piKVM & default output were set to mirror
   (e.g. When both were set to `pos 0,0`)
 - This caused redraw ordering bugs between the bars
   - Both bars would technically exist and be "drawn" on the same Wayland layer
   - One bar would "win" the draw ordering and be displayed on "top"
   - Thus, that bar would be the only one seen on both displays,
     and the active workspace numbering may or may not be correct depending on
     which you were viewing & controlling the desktop from.
   - Ordering of which was on "top" seemed to depend on a race condition during
     sway + waybar startup
 - To fix: Only draw the bars for all displays _except_ the piKVM
 - The "!" negates the output match pattern string
 - The "*" effectively matches all outputs except the piKVM excluded above it
