### PR TITLE
.config/sway: Fix wl-clip-persist RegEx syntax

### DIFF
--- a/dot_config/sway/definitions.d/02-override-cliphist.conf
+++ b/dot_config/sway/definitions.d/02-override-cliphist.conf
@@ -4,5 +4,5 @@ set $cliphist_store '[ -x "$(command -v wl-paste)" ] && [ -x "$(command -v cliph
 
 # Don't persist passwords (e.g. from KeePassXC)
 # https://github.com/Linus789/wl-clip-persist?tab=readme-ov-file#is-it-possible-to-ignore-clipboard-events-from-password-managers
-set $clip-persist '[ -x "$(command -v wl-clip-persist)" ] && pkill -x wl-clip-persist; wl-clip-persist --clipboard regular --all-mime-type-regex \'(?i)^(?!image/x-inkscape-svg|x-kde-passwordManagerHint).+\''
+set $clip-persist '[ -x "$(command -v wl-clip-persist)" ] && pkill -x wl-clip-persist; wl-clip-persist --clipboard regular --all-mime-type-regex "'(?i)^(?!image/x-inkscape-svg|x-kde-passwordManagerHint).+'"'
 


### PR DESCRIPTION
Note: Syntax error caused by "!" character (shell's histexpand)

References:

 - https://zsh.sourceforge.io/Doc/Release/Expansion.html#Overview
 - https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
