### PR TITLE
fix xwayland negative coords

### DIFF
--- a/dot_config/kanshi/config
+++ b/dot_config/kanshi/config
@@ -20,6 +20,8 @@ profile hdtv-extended {
 	# NOTE: alias vars do not yet work in exec
 	#exec swaymsg workspace 10, move workspace to output '$vizio_m601d_output_desc'
 	#exec swaymsg workspace 1, move workspace to output '$lg_oled_output_desc'
+	exec swaymsg "output 'LG Electronics LG TV SSCR2 0x01010101' enable"
+	exec swaymsg "output 'VIZIO, Inc M601d-A3/A3R 0x01010101' enable"
 	exec swaymsg "focus output 'VIZIO, Inc M601d-A3/A3R 0x01010101', workspace 10, workspace number 10 output 'VIZIO, Inc M601d-A3/A3R 0x01010101'"
 	exec swaymsg "focus output 'LG Electronics LG TV SSCR2 0x01010101'"
 }

--- a/dot_config/kanshi/config
+++ b/dot_config/kanshi/config
@@ -20,6 +20,8 @@ profile hdtv-extended {
 	# NOTE: alias vars do not yet work in exec
 	#exec swaymsg workspace 10, move workspace to output '$vizio_m601d_output_desc'
 	#exec swaymsg workspace 1, move workspace to output '$lg_oled_output_desc'
+	exec swaymsg "focus output 'VIZIO, Inc M601d-A3/A3R 0x01010101', workspace 10, workspace number 10 output 'VIZIO, Inc M601d-A3/A3R 0x01010101'"
+	exec swaymsg "focus output 'LG Electronics LG TV SSCR2 0x01010101'"
 }
 
 profile pikvm-mirrored {

--- a/dot_config/kanshi/config
+++ b/dot_config/kanshi/config
@@ -15,8 +15,8 @@ profile default {
 }
 
 profile hdtv-extended {
-	output $lg_oled_output_desc position 0,0 scale 2
-	output $vizio_m601d_output_desc position -1920,0 scale 1
+	output $lg_oled_output_desc position 1920,0 scale 2
+	output $vizio_m601d_output_desc position 0,0 scale 1
 	# NOTE: alias vars do not yet work in exec
 	#exec swaymsg workspace 10, move workspace to output '$vizio_m601d_output_desc'
 	#exec swaymsg workspace 1, move workspace to output '$lg_oled_output_desc'


### PR DESCRIPTION
- **.config/kanshi: Use positive coords to avoid XWayland mouse bug**
- **.config/kanshi: Workaround output workspace default numbering**
- **.config/kanshi: Workaround for disabled displays**



Notes:

  - [`kanshi`'s output alias feature](https://todo.sr.ht/~emersion/kanshi/106)
    does not support alias expansion in `exec` config lines
  - Sway treats the display at position `0,0` as the default output
  - For a right-handed output preference (main display on the right),
    we could use negative coordinates for the secondary display to
    achieve this.  However, this runs into XWayland bug:
    https://gitlab.freedesktop.org/xorg/xserver/-/issues/899
  - So, to workaround that bug we need to use non-negative coordinates
    and make the (left) secondary display start at position `0,0` instead.
  - This results in Sway treating the left display as primary by default.
  - To work around this side-effect, we must tell `kanshi` to reorder workspace
    number 1 on the right-hand output, and place the left-hand output on workspace
    number 10.
  - 7664ce8 introduced some errors when displays turn off due to standby
      timeout

Errors were:

    reloading config
    applying profile 'hdtv-extended'
    applying profile output 'LG Electronics LG TV SSCR2 0x01010101' on connected head 'HDMI-A-4'
    applying profile output 'VIZIO, Inc M601d-A3/A3R 0x01010101' on connected head 'HDMI-A-5'
    running command 'swaymsg focus\ output\ \'VIZIO,\ Inc\ M601d-A3/A3R\ 0x01010101\',\ workspace\ 10,\ workspace\ number\ 10\ output\ \'VIZIO,\ Inc\ M601d-A3/A3R\ 0x01010101\''
    running command 'swaymsg focus\ output\ \'LG\ Electronics\ LG\ TV\ SSCR2\ 0x01010101\''
    configuration for profile 'hdtv-extended' applied
     [
       {
         "success": false,
         "parse_error": true,
         "error": "Can't run this command while there's no outputs connected."
       }
     ]
    reloading config
    applying profile 'hdtv-extended'
    applying profile output 'LG Electronics LG TV SSCR2 0x01010101' on connected head 'HDMI-A-4'
    applying profile output 'VIZIO, Inc M601d-A3/A3R 0x01010101' on connected head 'HDMI-A-5'
    running command 'swaymsg focus\ output\ \'VIZIO,\ Inc\ M601d-A3/A3R\ 0x01010101\',\ workspace\ 10,\ workspace\ number\ 10\ output\ \'VIZIO,\ Inc\ M601d-A3/A3R\ 0x01010101\''
    running command 'swaymsg focus\ output\ \'LG\ Electronics\ LG\ TV\ SSCR2\ 0x01010101\''
    configuration for profile 'hdtv-extended' applied
     [
       {
         "success": false,
         "parse_error": true,
         "error": "Can't run this command while there's no outputs connected."
       }
     ]