### PR TITLE
update manjaro swayidle config

### DIFF
--- a/dot_config/sway/definitions.d/02-override-swaylock.conf
+++ b/dot_config/sway/definitions.d/02-override-swaylock.conf
@@ -11,19 +11,9 @@
 set $locking swaylock --daemonize --image $vizio_m601d_output_name:/usr/share/backgrounds/wizard4-by-rfk1ll.jpg --image "$lg_oled_output_name:${XDG_PICTURES_DIR}/backgrounds/oled-pure-black-3840x2160.png"
 
 ### Idle configuration
-# This will lock your screen after 300 seconds of inactivity, then turn off
-# your displays after another 300 seconds, and turn your screens back on when
-# resumed. It will also lock your screen before your computer goes to sleep.
-#
-set $idle_timeout 240
-set $locking_timeout 300
-set $screen_timeout 600
-set $sleep_timeout 900
+# This will lock your screen before your computer goes to sleep.
+# See: https://github.com/manjaro-sway/manjaro-sway/issues/466
 set $sleep_delay 2
-
-#set $systemctl_suspend 'systemctl suspend'
-# Shell no-op to turn off suspend
-set $systemctl_suspend :
 
 set $swayidle swayidle -w -S seat0 \
     idlehint $idle_timeout \

--- a/dot_config/sway/definitions.d/02-override-swaylock.conf
+++ b/dot_config/sway/definitions.d/02-override-swaylock.conf
@@ -15,14 +15,15 @@ set $locking swaylock --daemonize --image $vizio_m601d_output_name:/usr/share/ba
 # See: https://github.com/manjaro-sway/manjaro-sway/issues/466
 set $sleep_delay 2
 
-set $swayidle swayidle -w -S seat0 \
-    idlehint $idle_timeout \
-    timeout $idle_timeout 'light -G > /tmp/brightness && light -S 10' resume 'light -S $([ -f /tmp/brightness ] && cat /tmp/brightness || echo 100%)' \
-    timeout $locking_timeout 'exec $locking' \
-    timeout $screen_timeout 'swaymsg "output * power off"' \
-      resume 'swaymsg "output * power on"' \
-    timeout $screen_timeout 'sudo pkill -USR2 cec-dpms' \
-      resume 'sudo pkill -USR1 cec-dpms' \
-    before-sleep 'playerctl pause' \
-    before-sleep 'exec $locking & sleep $sleep_delay'
+## Moved to $XDG_CONFIG_HOME/sway/idle.yaml & swayidle-conf SystemD user service
+# set $swayidle swayidle -w -S seat0 \
+#     idlehint $idle_timeout \
+#     timeout $idle_timeout 'light -G > /tmp/brightness && light -S 10' resume 'light -S $([ -f /tmp/brightness ] && cat /tmp/brightness || echo 100%)' \
+#     timeout $locking_timeout 'exec $locking' \
+#     timeout $screen_timeout 'swaymsg "output * power off"' \
+#       resume 'swaymsg "output * power on"' \
+#     timeout $screen_timeout 'sudo pkill -USR2 cec-dpms' \
+#       resume 'sudo pkill -USR1 cec-dpms' \
+#     before-sleep 'playerctl pause' \
+#     before-sleep 'exec $locking & sleep $sleep_delay'
 

--- a/dot_config/sway/idle.yaml
+++ b/dot_config/sway/idle.yaml
@@ -16,7 +16,7 @@ timeouts:
   # screen_timeout
   - timeout: 600
     command: swaymsg "output * power off"
-    resume: swaymsg "output * power on"
+    resume: swaymsg "output * power on"; swaymsg "output * enable"
   # dpms_timeout
   - timeout: 600
     ## /etc/sudoers.d/70-power-allow-cec-dpms

--- a/dot_config/sway/idle.yaml
+++ b/dot_config/sway/idle.yaml
@@ -23,12 +23,13 @@ timeouts:
     ##     %power ALL = NOPASSWD: /usr/bin/pkill * cec-dpms
     command: sudo pkill -USR2 cec-dpms
     resume: sudo pkill -USR1 cec-dpms
+  ## Disable sleep/suspend/suspend-then-hibernate
   # sleep_timeout_bat
-  - timeout: 900
-    command: acpi -b | grep Discharging && systemctl sleep
+  #- timeout: 900
+  #  command: acpi -b | grep Discharging && systemctl sleep
   # sleep_timeout_ac
-  - timeout: 3600
-    command: acpi -b | grep Discharging; test $? -eq 1 && systemctl sleep
+  #- timeout: 3600
+  #  command: acpi -b | grep Discharging; test $? -eq 1 && systemctl sleep
 before-sleep: swaymsg exec \$locking
 after-resume: swaymsg "output * dpms on"
 lock: swaymsg exec \$locking

--- a/dot_config/sway/idle.yaml
+++ b/dot_config/sway/idle.yaml
@@ -19,8 +19,10 @@ timeouts:
     resume: swaymsg "output * power on"
   # dpms_timeout
   - timeout: 600
-    command: swaymsg "output * dpms off"
-    resume: swaymsg "output * dpms on"
+    ## /etc/sudoers.d/70-power-allow-cec-dpms
+    ##     %power ALL = NOPASSWD: /usr/bin/pkill * cec-dpms
+    command: sudo pkill -USR2 cec-dpms
+    resume: sudo pkill -USR1 cec-dpms
   # sleep_timeout_bat
   - timeout: 900
     command: acpi -b | grep Discharging && systemctl sleep

--- a/dot_config/sway/idle.yaml
+++ b/dot_config/sway/idle.yaml
@@ -30,7 +30,12 @@ timeouts:
   # sleep_timeout_ac
   #- timeout: 3600
   #  command: acpi -b | grep Discharging; test $? -eq 1 && systemctl sleep
-before-sleep: swaymsg exec \$locking
-after-resume: swaymsg "output * dpms on"
-lock: swaymsg exec \$locking
+events:
+  - before-sleep: playerctl pause
+  - before-sleep: 'swaymsg exec \$locking & sleep \$sleep_delay'
+  - after-resume: swaymsg "output * power on"
+  - lock: swaymsg exec \$locking
+before-sleep: null
+after-resume: null
+lock: null
 idlehint: '240'

--- a/dot_config/sway/idle.yaml
+++ b/dot_config/sway/idle.yaml
@@ -1,0 +1,33 @@
+---
+debug: true
+wait: false
+timeouts:
+  # idle_timeout
+  - timeout: 240
+    command: brightnessctl -s && brightnessctl set 10
+    resume: brightnessctl -r
+  # locking_timeout
+  - timeout: 300
+    command: swaymsg exec \$locking
+  # keyboard_timeout
+  - timeout: 600
+    command: /usr/share/sway/scripts/keyboard-backlight-switch.sh off
+    resume: /usr/share/sway/scripts/keyboard-backlight-switch.sh on
+  # screen_timeout
+  - timeout: 600
+    command: swaymsg "output * power off"
+    resume: swaymsg "output * power on"
+  # dpms_timeout
+  - timeout: 600
+    command: swaymsg "output * dpms off"
+    resume: swaymsg "output * dpms on"
+  # sleep_timeout_bat
+  - timeout: 900
+    command: acpi -b | grep Discharging && systemctl sleep
+  # sleep_timeout_ac
+  - timeout: 3600
+    command: acpi -b | grep Discharging; test $? -eq 1 && systemctl sleep
+before-sleep: swaymsg exec \$locking
+after-resume: swaymsg "output * dpms on"
+lock: swaymsg exec \$locking
+idlehint: '240'


### PR DESCRIPTION
- **.config/sway: Import new swayidle-conf default YAML config**
- **swayidle: Reconfigure to use cec-dpms & migrate deprecated dpms on/off -> power on/off**
- **swayidle: Always enable outputs on resume to avoid problem where output was disabled**
- **swayidle: Disable ACPI battery triggered suspend-then-hibernate (this machine is HTPC, not laptop!)**
- **swayidle: Override default before-sleep/after-resume/lock events**
- **swayidle: Remove deprecated manjaro-sway-settings variables**
