### PR TITLE
swayidle: Lock GNOME keyrings on SystemD lock event & trigger via loginctl lock-session

### DIFF
--- a/dot_config/sway/idle.yaml
+++ b/dot_config/sway/idle.yaml
@@ -8,7 +8,10 @@ timeouts:
     resume: brightnessctl -r
   # locking_timeout
   - timeout: 300
-    command: swaymsg exec \$locking
+    command: loginctl lock-session
+    #command: >
+    #  dbus-send --session --dest=org.gnome.keyring --type=method_call --print-reply /org/freedesktop/secrets org.freedesktop.Secret.Service.LockService;
+    #  swaymsg exec \$locking
   # keyboard_timeout
   - timeout: 600
     command: /usr/share/sway/scripts/keyboard-backlight-switch.sh off
@@ -30,12 +33,9 @@ timeouts:
   # sleep_timeout_ac
   #- timeout: 3600
   #  command: acpi -b | grep Discharging; test $? -eq 1 && systemctl sleep
-events:
-  - before-sleep: playerctl pause
-  - before-sleep: 'swaymsg exec \$locking & sleep \$sleep_delay'
-  - after-resume: swaymsg "output * power on"
-  - lock: swaymsg exec \$locking
-before-sleep: null
-after-resume: null
-lock: null
+before-sleep: 'playerctl pause;
+  swaymsg exec \$locking & sleep \$sleep_delay'
+after-resume: swaymsg "output * power on"
+lock: 'dbus-send --session --dest=org.gnome.keyring --type=method_call --print-reply /org/freedesktop/secrets org.freedesktop.Secret.Service.LockService;
+  swaymsg exec \$locking'
 idlehint: '240'


### PR DESCRIPTION
Also remove configuration for multiple events.  It turns out `swayidle` does not
actually support this. It just appeared to based on the debug logs, but was
really overriding each event with the command value of the last one passed.

Reference:
  https://github.com/xdbob/sway-services/pull/32#issuecomment-2638347633
