### PR TITLE
swaylock,swayidle: Fix systemd-logind session LockedHint & unlock handling

### DIFF
--- a/dot_config/sway/definitions.d/02-override-swaylock.conf
+++ b/dot_config/sway/definitions.d/02-override-swaylock.conf
@@ -8,7 +8,8 @@
 # Otherwise, we get segfault from swayidle PID
 ## NOTE: *_output_name macro vars expand only when the display is connected!
 #set $locking swaylock --debug --daemonize --image "$pikvm_output_name:/usr/share/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png" --image "$vizio_m601d_output_name:/usr/share/backgrounds/wizard4-by-rfk1ll.jpg" --image "$lg_oled_output_name:${XDG_PICTURES_DIR}/backgrounds/oled-pure-black-3840x2160.png"
-set $locking swaylock --daemonize --image $vizio_m601d_output_name:/usr/share/backgrounds/wizard4-by-rfk1ll.jpg --image "$lg_oled_output_name:${XDG_PICTURES_DIR}/backgrounds/oled-pure-black-3840x2160.png"
+set $locking loginctl lock-session
+set $swaylock swaylock --daemonize --image $vizio_m601d_output_name:/usr/share/backgrounds/wizard4-by-rfk1ll.jpg --image "$lg_oled_output_name:${XDG_PICTURES_DIR}/backgrounds/oled-pure-black-3840x2160.png"
 
 ### Idle configuration
 # This will lock your screen before your computer goes to sleep.

--- a/dot_config/sway/idle.yaml
+++ b/dot_config/sway/idle.yaml
@@ -9,9 +9,6 @@ timeouts:
   # locking_timeout
   - timeout: 300
     command: loginctl lock-session
-    #command: >
-    #  dbus-send --session --dest=org.gnome.keyring --type=method_call --print-reply /org/freedesktop/secrets org.freedesktop.Secret.Service.LockService;
-    #  swaymsg exec \$locking
   # keyboard_timeout
   - timeout: 600
     command: /usr/share/sway/scripts/keyboard-backlight-switch.sh off
@@ -34,8 +31,10 @@ timeouts:
   #- timeout: 3600
   #  command: acpi -b | grep Discharging; test $? -eq 1 && systemctl sleep
 before-sleep: 'playerctl pause;
-  swaymsg exec \$locking & sleep \$sleep_delay'
+  loginctl lock-session & sleep \$sleep_delay'
 after-resume: swaymsg "output * power on"
 lock: 'dbus-send --session --dest=org.gnome.keyring --type=method_call --print-reply /org/freedesktop/secrets org.freedesktop.Secret.Service.LockService;
-  swaymsg exec \$locking'
+  dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1/session/auto org.freedesktop.login1.Session.SetLockedHint boolean:true;
+  swaymsg exec \$swaylock'
+unlock: dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1/session/auto org.freedesktop.login1.Session.SetLockedHint boolean:false
 idlehint: '240'


### PR DESCRIPTION
Note: The unlock behavior to launch `loginctl unlock-session` and trigger `lock`
SystemD event depends on a PAM configuration using `pam_exec.so`.
The integration to automatically unlock `gnome-keyring-daemon` depends on
`pam_gnome_keyring.so`

Example swaylock PAM configuration below.

`/etc/pam.d/swaylock`:

    #
    # PAM configuration file for the swaylock screen locker. By default, it includes
    # the 'login' configuration file (see /etc/pam.d/login)
    #

    auth       include      login
    -auth      optional     pam_gnome_keyring.so
    -auth      optional     pam_exec.so debug type=auth /usr/bin/loginctl unlock-session
    -session   optional     pam_gnome_keyring.so auto_start
