### PR TITLE
.config/sway: Disable findex def & binding

### DIFF
--- a/dot_config/sway/config.d/04-findex.conf
+++ b/dot_config/sway/config.d/04-findex.conf
@@ -1,4 +1,6 @@
 # Copyright (C) © 🄯  2023-2024 James Cuzella
 # This program is free software: See LICENSE
 # Activate findex
-bindsym --no-repeat $mod+$alt_mod+space exec $findex
+# Note: Currently broken due to gtk errors
+# Reference: https://github.com/mdgaziur/findex/issues/27
+# bindsym --no-repeat $mod+$alt_mod+space exec $findex

--- a/dot_config/sway/definitions.d/05-findex.conf
+++ b/dot_config/sway/definitions.d/05-findex.conf
@@ -3,5 +3,7 @@
 #
 # bind: ~/.config/sway/config.d/04-findex.conf
 #set $findex '[ -x "$(command -v findex)" ] &&  'touch \$XDG_CONFIG_DIR/findex/toggle_file && echo 1 > \$XDG_CONFIG_DIR/findex/toggle_file''
-set $findex 'echo 1 > "${XDG_CONFIG_HOME:-${HOME}/.config}"/findex/toggle_file'
+# Note: Currently broken due to gtk errors
+# Reference: https://github.com/mdgaziur/findex/issues/27
+# set $findex 'echo 1 > "${XDG_CONFIG_HOME:-${HOME}/.config}"/findex/toggle_file'
 


### PR DESCRIPTION
...to avoid disk filling up with logs

Note: Currently broken due to gtk errors

Reference: mdgaziur/findex#27
