### PR TITLE
add tmux config

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -22,6 +22,9 @@ README.md
 {{ if not (lookPath "nwg-wrapper") -}}
 .config/nwg-wrapper
 {{ end -}}
+{{ if not (lookPath "tmux") -}}
+.config/tmux
+{{ end -}}
 {{ if not (lookPath "waybar") -}}
 .config/waybar
 {{ end -}}

--- a/dot_config/oh-my-zsh/zshrc.tmpl
+++ b/dot_config/oh-my-zsh/zshrc.tmpl
@@ -99,7 +99,7 @@ plugins=(git pyenv python vscode zsh-sweep zhooks)
 
 # Use p10k built-in OSC 133 semantic prompt support
 # order-of-operations: must be set before p10k is sourced (via OMZ's ZSH_THEME)
-typeset -g POWERLEVEL9K_TERM_SHELL_INTEGRATION=true
+typeset -gri __p9k_force_term_shell_integration=1
 
 # zsweep plugin
 zs_set_path=1

--- a/dot_config/oh-my-zsh/zshrc.tmpl
+++ b/dot_config/oh-my-zsh/zshrc.tmpl
@@ -137,7 +137,6 @@ if [[ ! -d "${ZSH_CACHE_DIR}/completions" ]]; then
 fi
 
 source $ZSH/oh-my-zsh.sh
-
 {{- /* Manjaro uses /usr/share/zsh/p10k.zsh from extra/manjaro-zsh-config */ -}}
 {{ if ne .osId "manjaro" -}}
 {{/* Source p10k config (output of p10k configure) on everything except Manjaro */}}

--- a/dot_config/oh-my-zsh/zshrc.tmpl
+++ b/dot_config/oh-my-zsh/zshrc.tmpl
@@ -97,6 +97,10 @@ plugins=(git pyenv python vscode zsh-sweep zhooks)
 
 # User configuration
 
+# Use p10k built-in OSC 133 semantic prompt support
+# order-of-operations: must be set before p10k is sourced (via OMZ's ZSH_THEME)
+typeset -g POWERLEVEL9K_TERM_SHELL_INTEGRATION=true
+
 # zsweep plugin
 zs_set_path=1
 

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -107,5 +107,5 @@ bind-key -T copy-mode-vi y send-keys -X copy-pipe "{{ $copy_cmd }}"
 unbind -T copy-mode-vi Enter
 bind-key -T copy-mode-vi Enter send-keys -X copy-pipe "{{ $copy_cmd }}"
 
-# Bind ']' to use wl-paste
+# Bind ']' to use {{ $paste_cmd }}
 bind ] run "{{ $paste_cmd }} | tmux load-buffer - && tmux paste-buffer"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -77,6 +77,10 @@ set-option -g terminal-overrides '*88col*:colors=88,*256col*:colors=256,xterm*:X
 {{   $comment_str = "" -}}
 {{   $copy_cmd = "pbcopy" -}}
 {{   $paste_cmd = "pbpaste" -}}
+{{   if lookPath "reattach-to-user-namespace" -}}
+{{     $copy_cmd = printf "%s%s" "reattach-to-user-namespace " $copy_cmd -}}
+{{     $paste_cmd = printf "%s%s" "reattach-to-user-namespace " $paste_cmd -}}
+{{   end -}}
 {{ else if (eq .chezmoi.os "windows") -}}
 {{   $comment_str = "Windows Subsystem for Linux" -}}
 {{   $copy_cmd = "perl -pe 'chomp if eof' | clip.exe" -}}

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -39,6 +39,14 @@ set -g mouse on
 # scrollback buffer size increase
 set -g history-limit 500000
 
+# Copy-mode OSC 133 shell integration
+# C-z scrolls back to last prompt
+#bind-key -T copy-mode  /  \; send-keys -X previous-prompt \; send-keys -X previous-prompt \; send-key /
+bind-key -T copy-mode    C-z send-keys -X next-prompt
+bind-key -T copy-mode-vi C-z send-keys -X next-prompt
+bind-key -T copy-mode    C-x send-keys -X previous-prompt
+bind-key -T copy-mode-vi C-x send-keys -X previous-prompt
+
 # C-b C-b will swap to last used window
 bind-key C-b last-window
 

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -40,12 +40,13 @@ set -g mouse on
 set -g history-limit 500000
 
 # Copy-mode OSC 133 shell integration
-# C-z scrolls back to last prompt
+# C-z scrolls back to last old prompt
+# C-x scrolls forward to later prompt
 #bind-key -T copy-mode  /  \; send-keys -X previous-prompt \; send-keys -X previous-prompt \; send-key /
-bind-key -T copy-mode    C-z send-keys -X next-prompt
-bind-key -T copy-mode-vi C-z send-keys -X next-prompt
-bind-key -T copy-mode    C-x send-keys -X previous-prompt
-bind-key -T copy-mode-vi C-x send-keys -X previous-prompt
+bind-key -T copy-mode    C-z send-keys -X previous-prompt
+bind-key -T copy-mode-vi C-z send-keys -X previous-prompt
+bind-key -T copy-mode    C-x send-keys -X next-prompt
+bind-key -T copy-mode-vi C-x send-keys -X next-prompt
 
 # C-b C-b will swap to last used window
 bind-key C-b last-window

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -62,7 +62,31 @@ bind - split-window -v
 set-option -g terminal-overrides '*88col*:colors=88,*256col*:colors=256,xterm*:XT:Ms=\E]52;%p1%s;%p2%s\007:Cc=\E]12;%p1%s\007:Cr=\E]112\007:Cs=\E]50;CursorShape=%?%p1%{3}%<%t%{0}%e%p1%{2}%-%;%d\007'
 
 
-# tmux OSX pbcopy integration => Adapted to wl-copy for Wayland Linux
+{{ $comment_str := "" -}}
+{{ $copy_cmd := "" -}}
+{{ $paste_cmd := "" -}}
+{{ if (eq .chezmoi.os "linux") | and ((lookPath "wayland-scanner") | or (eq .xdg_session_type "wayland")) -}}
+{{   $comment_str = "Wayland Linux" -}}
+{{   $copy_cmd = "wl-copy" -}}
+{{   $paste_cmd = "wl-paste" -}}
+{{ else if (eq .chezmoi.os "linux") -}}
+{{   $comment_str = "Xorg Linux" -}}
+{{   $copy_cmd = "xclip -selection clipboard -in" -}}
+{{   $paste_cmd = "xclip -selection clipboard -o" -}}
+{{ else if (eq .chezmoi.os "darwin") -}}
+{{   $comment_str = "" -}}
+{{   $copy_cmd = "pbcopy" -}}
+{{   $paste_cmd = "pbpaste" -}}
+{{ else if (eq .chezmoi.os "windows") -}}
+{{   $comment_str = "Windows Subsystem for Linux" -}}
+{{   $copy_cmd = "perl -pe 'chomp if eof' | clip.exe" -}}
+{{   $paste_cmd = "powershell.exe Get-Clipboard | sed 's/\r$//'" -}}
+{{ else -}}
+{{   $comment_str = "Xorg Unknown OS" -}}
+{{   $copy_cmd = "xclip -selection clipboard -in" -}}
+{{   $paste_cmd = "xclip -selection clipboard -o" -}}
+{{ end -}}
+# tmux OSX pbcopy integration{{ if ne $comment_str "" }} => Adapted to {{ $copy_cmd }} for {{ $comment_str }}{{ end }}
 # Source: http://evertpot.com/osx-tmux-vim-copy-paste-clipboard/
 # Linux method reference: https://github.com/nicknisi/dotfiles/pull/167
 # Copy-paste integration
@@ -73,11 +97,11 @@ setw -g mode-keys vi
 
 # Setup 'v' to begin selection as in Vim
 bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind-key -T copy-mode-vi y send-keys -X copy-pipe "wl-copy"
+bind-key -T copy-mode-vi y send-keys -X copy-pipe "{{ $copy_cmd }}"
 
 # Update default binding of `Enter` to also use copy-pipe
 unbind -T copy-mode-vi Enter
-bind-key -T copy-mode-vi Enter send-keys -X copy-pipe "wl-copy"
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe "{{ $copy_cmd }}"
 
-# Bind ']' to use pbpaste
-bind ] run "wl-paste | tmux load-buffer - && tmux paste-buffer"
+# Bind ']' to use wl-paste
+bind ] run "{{ $paste_cmd }} | tmux load-buffer - && tmux paste-buffer"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -1,0 +1,83 @@
+# Act like Vim
+set-window-option -g mode-keys vi
+bind-key h select-pane -L
+bind-key j select-pane -D
+bind-key k select-pane -U
+bind-key l select-pane -R
+
+# Use zsh default
+#set-option -g default-shell /usr/bin/zsh
+set-option -g default-shell $SHELL
+
+# Look good
+#set-option -g default-terminal "screen-256color"
+
+# Set terminal title from active tmux window/panes
+set-option -g allow-rename on
+set-option -g set-titles on
+set-option -g set-titles-string 'tmux #{pane_title}'
+set -g default-terminal "xterm-256color"
+#set-option -g default-terminal "xterm-256color"
+
+#set -g set-titles on
+#set -g set-titles-string "#W"
+#set -g default-terminal "tmux-256color"
+
+# Enable mouse support (works in iTerm)
+#set-window-option -g mode-mouse on
+#set-option -g mouse-select-pane on
+#set-option -g mouse-resize-pane on
+#set-option -g mouse-select-window on
+# Tmux >=2.1 deprecated above options.
+# Reference: https://stackoverflow.com/questions/11832199/tmux-set-g-mouse-mode-on-doesnt-work
+# Now there is just:
+set -g mouse on
+
+# set up layouts
+# set main-pane-width 130
+
+# scrollback buffer size increase
+set -g history-limit 500000
+
+# C-b C-b will swap to last used window
+bind-key C-b last-window
+
+# Start tab numbering at 1
+set -g base-index 1
+
+# Allows for faster key repetition
+set -s escape-time 0
+
+# Highlight active window
+# Deprecated in Tmux v2.9.x
+#set-window-option -g window-status-current-bg red
+set -g mode-style bg=red,fg=green,blink
+
+# use different keys to split vertical and horizonal
+bind | split-window -h
+bind - split-window -v
+
+# Change cursor in vim to distinguish between insert and command mode
+# Use in conjunciton with tmux-cursors.vim
+set-option -g terminal-overrides '*88col*:colors=88,*256col*:colors=256,xterm*:XT:Ms=\E]52;%p1%s;%p2%s\007:Cc=\E]12;%p1%s\007:Cr=\E]112\007:Cs=\E]50;CursorShape=%?%p1%{3}%<%t%{0}%e%p1%{2}%-%;%d\007'
+
+
+# tmux OSX pbcopy integration => Adapted to wl-copy for Wayland Linux
+# Source: http://evertpot.com/osx-tmux-vim-copy-paste-clipboard/
+# Linux method reference: https://github.com/nicknisi/dotfiles/pull/167
+# Copy-paste integration
+#set-option -g default-command "bash"
+
+# Use vim keybindings in copy mode
+setw -g mode-keys vi
+
+# Setup 'v' to begin selection as in Vim
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-pipe "wl-copy"
+
+# Update default binding of `Enter` to also use copy-pipe
+unbind -T copy-mode-vi Enter
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe "wl-copy"
+
+# Bind ']' to use pbpaste
+bind ] run "wl-paste | tmux load-buffer - && tmux paste-buffer"

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -10,18 +10,16 @@ bind-key l select-pane -R
 set-option -g default-shell $SHELL
 
 # Look good
-#set-option -g default-terminal "screen-256color"
 
 # Set terminal title from active tmux window/panes
 set-option -g allow-rename on
 set-option -g set-titles on
 set-option -g set-titles-string 'tmux #{pane_title}'
+{{ if (eq .chezmoi.os "linux") -}}
 set-option -g default-terminal "tmux-256color"
-#set-option -g default-terminal "xterm-256color"
-
-#set -g set-titles on
-#set -g set-titles-string "#W"
-#set -g default-terminal "tmux-256color"
+{{ else if (eq .chezmoi.os "darwin") -}}
+set-option -g default-terminal "screen-256color"
+{{ end -}}
 
 # Enable mouse support (works in iTerm)
 #set-window-option -g mode-mouse on

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -16,7 +16,7 @@ set-option -g default-shell $SHELL
 set-option -g allow-rename on
 set-option -g set-titles on
 set-option -g set-titles-string 'tmux #{pane_title}'
-set -g default-terminal "xterm-256color"
+set-option -g default-terminal "tmux-256color"
 #set-option -g default-terminal "xterm-256color"
 
 #set -g set-titles on

--- a/dot_config/zsh/config.d/00-precmd.zsh
+++ b/dot_config/zsh/config.d/00-precmd.zsh
@@ -1,4 +1,4 @@
-typeset -g POWERLEVEL9K_TERM_SHELL_INTEGRATION=true
+# Now using p10k OSC 133 integration in ~/.config/oh-my-zsh/zshrc
 #function mzc_termsupport_prompt_jump() {
 #    print -Pn "\e]133;A\e\\"
 #}

--- a/dot_config/zsh/config.d/00-precmd.zsh
+++ b/dot_config/zsh/config.d/00-precmd.zsh
@@ -1,7 +1,8 @@
-function mzc_termsupport_prompt_jump() {
-    print -Pn "\e]133;A\e\\"
-}
-add-zsh-hook precmd mzc_termsupport_prompt_jump
+typeset -g POWERLEVEL9K_TERM_SHELL_INTEGRATION=true
+#function mzc_termsupport_prompt_jump() {
+#    print -Pn "\e]133;A\e\\"
+#}
+#add-zsh-hook precmd mzc_termsupport_prompt_jump
 
 #precmd() {
 #    echo 'Adding precmd prompt OSC 133'


### PR DESCRIPTION
- **.chezmoiignore: Omit tmux configs if not installed**
- **.config/tmux: Add Wayland copy/paste integration tmux config**
- **.config/tmux: Template-ify tmux config copy/paste integration**
- **.config/tmux: Use reattach-to-user-namespace wrapper on OSX if found**
- **.config/tmux: Fix copy-mode ']' binding comment**
- **.config/tmux: Add OSC 133 prompt scrollback integration**
- **.config/zsh: Use p10k built-in OSC 133 semantic prompt support**
- **.conf/tmux: Fix default TERM termcap string -> tmux-256color**
