### PR TITLE
.chezmoiignore: Fix logic to omit gtk-* on non-Linux OS

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -129,20 +129,20 @@ README.md
 {{ if not (eq .chezmoi.os "linux") -}}
 .config/mimeapps.list
 .local/share/applications/mimeapps.list
+{{ end -}}
 {{- /* Omit specific GTK versioned settings when not installed */ -}}
-{{   if not (lookPath "gtk-query-immodules-2.0") -}}
+{{ if not (eq .chezmoi.os "linux") | or (not (lookPath "gtk-query-immodules-2.0")) -}}
 # Don't install gtk2 settings
 .config/gtk-2.0
 .gtkrc-2.0
-{{   end -}}
-{{   if not (lookPath "gtk-query-immodules-3.0") -}}
+{{ end -}}
+{{ if not (eq .chezmoi.os "linux") | or (not (lookPath "gtk-query-immodules-3.0")) -}}
 # Don't install gtk3 settings
 .config/gtk-3.0
-{{   end -}}
-{{   if not (lookPath "gtk4-query-settings") -}}
+{{ end -}}
+{{ if not (eq .chezmoi.os "linux") | or (not (lookPath "gtk4-query-settings")) -}}
 # Don't install gtk4 settings
 .config/gtk-4.0
-{{   end -}}
 {{ end -}}
 {{ if not (eq .chezmoi.os "linux") | or (not (lookPath "systemctl")) -}}
 # Don't install SystemD units


### PR DESCRIPTION
Note: DeMorgan's theorem applies b/c logic for .chezmoiignore is inverted via
conditional:

    not (linux * lookPath ...)

Simplifying to:

    not linux + not lookPath ...

So, we must combine with logical OR instead of nested `if` conditions.
