### PR TITLE
.chezmoiexternal.yaml.tmpl: Switch to upstream duckdns-systemd (now has IPv6 support)

### DIFF
--- a/.chezmoiexternal.yaml.tmpl
+++ b/.chezmoiexternal.yaml.tmpl
@@ -76,11 +76,9 @@
 {{ if eq .chezmoi.hostname "saturn" | and ( eq .chezmoi.uid "1000" ) -}}
 ".local/share/duckdns-systemd":
   type: "git-repo"
-  url: "https://github.com/trinitronx/duckdns-systemd"
+  url: "https://github.com/orazioedoardo/duckdns-systemd"
   refreshPeriod: "168h"
   pull:
     args: ["--ff-only"]
-  clone:
-    args: ["-b", "add-ipv6-support"]
 
 {{ end -}}


### PR DESCRIPTION
Note: orazioedoardo/duckdns-systemd#4 was merged!
