### PR TITLE
mako utils

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -128,6 +128,15 @@ README.md
 {{ if not (lookPath "qt6ct") -}}
 .config/qt6ct
 {{ end -}}
+{{- /* Omit makoctl imv/mpv helper utils if not installed */ -}}
+{{ if not (lookPath "makoctl") -}}
+{{   if not (lookPath "imv") -}}
+.local/bin/imv-last-screenshot.sh
+{{   end -}}
+{{   if not (lookPath "mpv") -}}
+.local/bin/mpv-last-video.sh
+{{   end -}}
+{{ end -}}
 {{- /* Omit Linux-specific settings on non-Linux OS */ -}}
 {{ if not (eq .chezmoi.os "linux") -}}
 .config/mimeapps.list

--- a/private_dot_local/bin/executable_imv-last-screenshot.sh
+++ b/private_dot_local/bin/executable_imv-last-screenshot.sh
@@ -13,4 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <https://www.gnu.org/licenses/>.
 
-makoctl history | jq -r '.data | .[] | map(select(.summary.data == "Screenshot saved")) | first | .body.data'  | imv
+makoctl history | jq -r '.data | .[] |
+    map(
+      select(.summary.data == "Screenshot saved")
+    ) | first | .body.data' | \
+  imv

--- a/private_dot_local/bin/executable_imv-last-screenshot.sh
+++ b/private_dot_local/bin/executable_imv-last-screenshot.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Copyright (C) © 🄯  2023-2025 James Cuzella
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>.
+
+makoctl history | jq -r '.data | .[] | map(select(.summary.data == "Screenshot saved")) | first | .body.data'  | imv

--- a/private_dot_local/bin/executable_mpv-last-video.sh
+++ b/private_dot_local/bin/executable_mpv-last-video.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Copyright (C) © 🄯  2023-2025 James Cuzella
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>.
+
+makoctl history | jq -r '.data | .[] | 
+    map(
+      select(.summary.data == "Recording" and 
+        (.body.data | test("^Finished recording "))
+      )
+    ) | first | .body.data' | \
+  sed -e 's/^Finished recording //'  | xargs mpv --


### PR DESCRIPTION
- **.local/bin/imv-last-screenshot.sh: Add mako history imv last screenshot helper**
- **.local/bin/imv-last-screenshot.sh: Improve jq query readability**
- **.local/bin/mpv-last-video.sh: Add mako history mpv last video helper**
- **.chezmoiignore: Omit makoctl imv/mpv helper utils if not installed**
