### PR TITLE
.config/mpv: Migrate deprecated CLI option: --load-osd-console -> --load-console

### DIFF
--- a/dot_config/private_mpv/mpv.conf
+++ b/dot_config/private_mpv/mpv.conf
@@ -42,7 +42,7 @@ mute=yes
 load-scripts=no
 osc=no
 load-stats-overlay=no
-load-osd-console=no
+load-console=no
 load-auto-profiles=yes
 load-select=no
 


### PR DESCRIPTION
Warning was:

    Warning: option --load-osd-console was replaced with --load-console and might be removed in the future.
