### PR TITLE
.config/gtk-2.0/gtkfilechooser.ini: Update & track as externally modified file

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -147,6 +147,10 @@ README.md
 # Don't install gtk2 settings
 .config/gtk-2.0
 .gtkrc-2.0
+{{ else -}}
+{{- /* Omit specific GTK 2.0 externally-modified files */ -}}
+# Ignore externally modified file (will exist only in chezmoi source-path)
+.config/gtk-2.0/gtkfilechooser.ini.chezmoi-real
 {{ end -}}
 {{ if not (eq .chezmoi.os "linux") | or (not (lookPath "gtk-query-immodules-3.0")) -}}
 # Don't install gtk3 settings

--- a/dot_config/private_gtk-2.0/gtkfilechooser.ini.chezmoi-real
+++ b/dot_config/private_gtk-2.0/gtkfilechooser.ini.chezmoi-real
@@ -2,10 +2,10 @@
 LocationMode=filename-entry
 ShowHidden=false
 ShowSizeColumn=true
-GeometryX=0
-GeometryY=263
+GeometryX=456
+GeometryY=192
 GeometryWidth=1008
-GeometryHeight=583
-SortColumn=name
-SortOrder=ascending
+GeometryHeight=695
+SortColumn=modified
+SortOrder=descending
 StartupMode=recent

--- a/dot_config/private_gtk-2.0/symlink_gtkfilechooser.ini.tmpl
+++ b/dot_config/private_gtk-2.0/symlink_gtkfilechooser.ini.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/private_gtk-2.0/gtkfilechooser.ini.chezmoi-real


### PR DESCRIPTION
This file is externally modified whenever gtk's file chooser dialog window
settings or geometry are changed.  Thus, we should track this in chezmoi's
source state by symlinking the original back to this repo.  The changes will
show up in git diff whenever we need to update this file.

Reference:

- [Chezmoi Docs: Handle configuration files which are externally modified][1]

[1]: https://www.chezmoi.io/user-guide/manage-different-types-of-file/#handle-configuration-files-which-are-externally-modified
