### PR TITLE
.config/sway: Workaround HDMI electrical noise issues - Run LG TV at 4k@30Hz

### DIFF
--- a/dot_config/sway/config.d/01-output-hdmi-lg-oled-g4-subpixel-bgrw.conf
+++ b/dot_config/sway/config.d/01-output-hdmi-lg-oled-g4-subpixel-bgrw.conf
@@ -3,6 +3,13 @@
 ## 2024-12-03: JMC: Based on closeup photo + subpixel tests...
 ##   LG OLED G4 display is: BGRW supbixel layout
 output '$lg_oled_output_desc' {
+    ## TODO: Fix "no signal" & blackout issues when display runs at 4k@60Hz
+    ## This is an HDMI electrical signal noise issue from EMF interference.
+    ## Seems consistent with EMF noise, based on testing different HDMI cables,
+    ## and test cases with or without Tripp-Lite grounding block(s),
+    ## and Pulse-Eight CEC adapter (both with/without USB ground loop isolator)
+    ## Meanwhile, 4k@30Hz has been much more stable.
+    resolution 3840x2160@30Hz
     subpixel bgr
     scale 2
     pos 0,0


### PR DESCRIPTION
Problem: Observed "no signal" & transient yet frequent blackout issues when LG display runs at 4k@60Hz

This is definitely an HDMI electrical signal noise issue from EMF interference.

Seems consistent with Electro-Magnetic Field (EMF) induced noise, based on testing different HDMI cables, and other inline connection test cases.

Test cases included:

- Different HDMI cables (well shielded & lesser-quality thin cables) 
- With or without Tripp-Lite grounding block(s) on both HDMI cable ends
- With or without Pulse-Eight CEC adapter
  - Both with/without USB ground loop isolator on CEC adapter's USB cable interconnect to PC
  - Use of well shielded very short HDMI cables between each connection block (Pulse-Eight, Tripp-Lite)

Meanwhile, running the display at 4k@30Hz has been much more stable.

For now, this sway config band-aid patch will just override the default HDMI EDID-discovered resolution and rate as 4k@30Hz:

    resolution 3840x2160@30Hz