### PR TITLE
.gitconfig: Enable git notes display all namespaces

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -117,3 +117,4 @@
 	allowedSignersFile = {{ .chezmoi.homeDir }}/.config/git/allowed_signers
 [notes]
 	rewriteRef = refs/notes/commits
+	displayRef = refs/notes/*


### PR DESCRIPTION
Command:

    git config --global notes.displayRef 'refs/notes/*'
