### PR TITLE
.config/sway: Re-enable shortcuts_inhibitor for KVM / remote desktop apps

### DIFF
--- a/dot_config/sway/config.d/98-application-defaults.conf
+++ b/dot_config/sway/config.d/98-application-defaults.conf
@@ -98,3 +98,11 @@ for_window [class="Hyperbolica.*" title="Hyperbolica"] inhibit_idle fullscreen
 for_window [class="KSP\.x86_64.*" title="Kerbal Space Program"] inhibit_idle fullscreen
 for_window [class="KSP\.x86_64.*" title="Kerbal Space Program"] fullscreen enable
 
+
+# Keyboard shortcuts inhibitor allow
+# Note: Manjaro sets 'seat * shortcuts_inhibitor disable'
+for_window [app_id="org.remmina.Remmina"] shortcuts_inhibitor enable
+for_window [app_id="remote-viewer"] shortcuts_inhibitor enable
+for_window [app_id="wlfreerdp"] shortcuts_inhibitor enable
+for_window [class="sdl-freerdp3"] shortcuts_inhibitor enable
+


### PR DESCRIPTION
Notes:

- Manjaro Sway default configs disabled this globally

- No capture of mod/Super key made remote control nearly impossible for macOS inside VMs, VNC, etc... (because Cmd key maps to Super!)
