### PR TITLE
fix bootstrap snags

### DIFF
--- a/.chezmoiexternal.yaml.tmpl
+++ b/.chezmoiexternal.yaml.tmpl
@@ -1,15 +1,18 @@
+{{- if not (env "OFFLINE") }}
 ".config/oh-my-zsh/custom/plugins/zhooks":
   type: "git-repo"
   url: "https://github.com/agkozak/zhooks"
   refreshPeriod: "168h"
   pull:
     args: ["--ff-only"]
+
 ".config/oh-my-zsh/custom/plugins/zsh-sweep":
   type: "git-repo"
   url: "https://github.com/psprint/zsh-sweep"
   refreshPeriod: "168h"
   pull:
     args: ["--ff-only"]
+
 ".config/oh-my-zsh/custom/plugins/zsh-tmux-auto-title":
   type: "git-repo"
   url: "https://github.com/mbenford/zsh-tmux-auto-title"
@@ -17,7 +20,7 @@
   pull:
     args: ["--ff-only"]
 
-{{ if ne .osId "manjaro" -}}
+{{   if ne .osId "manjaro" -}}
 {{- /* Manjaro can rely on manjaro-sway/oh-my-zsh */ -}}
 ".local/share/oh-my-zsh":
   type: "git-repo"
@@ -25,8 +28,9 @@
   refreshPeriod: "168h"
   pull:
     args: ["--ff-only"]
-{{ end -}}
-{{ if ne .osFamily "linux-arch" -}}
+
+{{   end -}}
+{{   if ne .osFamily "linux-arch" -}}
 {{- /* Arch-based distros can use extra/zsh-theme-powerlevel10k */ -}}
 ".local/share/zsh-theme-powerlevel10k":
   type: "git-repo"
@@ -35,8 +39,8 @@
   pull:
     args: ["--ff-only"]
 
-{{- end }}
-{{ if lookPath "bat" -}}
+{{   end -}}
+{{   if lookPath "bat" -}}
 ".config/bat/themes/Dark-Dracula-Theme":
   type: "git-repo"
   url: "https://github.com/krman009/Dark-Dracula-Theme"
@@ -72,8 +76,8 @@
   pull:
     args: ["--ff-only"]
 
-{{ end -}}
-{{ if eq .chezmoi.hostname "saturn" | and ( eq .chezmoi.uid "1000" ) -}}
+{{   end -}}
+{{   if eq .chezmoi.hostname "saturn" | and ( eq .chezmoi.uid "1000" ) -}}
 ".local/share/duckdns-systemd":
   type: "git-repo"
   url: "https://github.com/orazioedoardo/duckdns-systemd"
@@ -81,4 +85,5 @@
   pull:
     args: ["--ff-only"]
 
+{{   end -}}
 {{ end -}}

--- a/.chezmoiexternal.yaml.tmpl
+++ b/.chezmoiexternal.yaml.tmpl
@@ -1,4 +1,9 @@
 {{- if not (env "OFFLINE") }}
+".cache/chezmoi/github-meta-api":
+  type: "file"
+  url: "https://api.github.com/meta"
+  private: true
+
 ".config/oh-my-zsh/custom/plugins/zhooks":
   type: "git-repo"
   url: "https://github.com/agkozak/zhooks"

--- a/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
@@ -25,11 +25,12 @@ if [ ! -e "{{ $sshKnownHosts }}" ]; then
   cat >>{{ $sshKnownHosts }}<<-EOKH
 {{    if stat (joinPath (.chezmoi.cacheDir | toString) "github-meta-api") -}}
 {{-     $gitKeys := get (include (joinPath (.chezmoi.cacheDir | toString) "github-meta-api") | fromJson) "ssh_keys" -}}
+# api.github.com/meta - {{ now | date "2006-01-02" }}
 {{      range $gitKeys }}github.com {{ . }}
 {{      end -}}
 {{-   else -}}
 {{- /* If API metadata was unavailable, use latest static keys as of 2025-07-03 */ -}}
-# Static
+# Static Chezmoi src dir - 2025-07-03
 github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
 github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
 github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=

--- a/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
@@ -12,7 +12,7 @@ fi
 {{/* Only add github.com SSH pubkeys on first bootstrap run */ -}}
 {{- /* Do not modify pre-existing ~/.ssh/known_hosts */ -}}
 {{- $sshDir := joinPath (.chezmoi.destDir | toString) ".ssh" -}}
-{{- $sshKnownHosts := joinPath $sshDir "known_hosts.modify_test" -}}
+{{- $sshKnownHosts := joinPath $sshDir "known_hosts" -}}
 if [ ! -e "{{ $sshKnownHosts }}" ]; then
   if [ ! -d "{{ $sshDir }}" ] ; then
     mkdir -p "{{ $sshDir }}"

--- a/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
@@ -1,17 +1,34 @@
-{{- /* chezmoi:modify-template */ -}}
+#!/bin/sh
+# -u bail on unset vars
+# -e bail on pipefail
+set -eu
+
+if [[ -z "${CHEZMOI_WORKING_TREE}" ]]; then
+    echo "Error, \$CHEZMOI_WORKING_TREE must be set. Please only run this script via chezmoi"
+    exit 1
+fi
+{{- /* vim: set ft=gotmpl */ -}}
 {{- /* Only add github.com SSH pubkeys on first bootstrap run */ -}}
-{{- if .chezmoi.stdin -}}
 {{- /* Do not modify pre-existing ~/.ssh/known_hosts */ -}}
-{{-   .chezmoi.stdin }}
-{{- else -}}
+{{- $sshDir := joinPath .chezmoi.destDir ".ssh" -}}
+{{- $sshKnownHosts := joinPath $sshDir "known_hosts.modify_test" -}}
+if [ ! -e "{{ $sshKnownHosts }}" ]; then
+  if [ ! -d "{{ $sshDir }}" ] ; then
+    mkdir -p "{{ $sshDir }}"
+    chmod 0700 "{{ $sshDir }}"
+  fi
+  cat >>{{ $sshKnownHosts }}<<-EOKH
 {{-   if stat (joinPath .chezmoi.cacheDir "github-meta-api") -}}
 {{-     $gitKeys := get (include (joinPath .chezmoi.cacheDir "github-meta-api") | fromJson) "ssh_keys" -}}
 {{      range $gitKeys }}github.com {{ . }}
 {{      end -}}
 {{-   else -}}
 {{- /* If API metadata was unavailable, use latest static keys as of 2025-07-03 */ -}}
+# Static
 github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
 github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
 github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
 {{    end -}}
-{{  end -}}
+EOKH
+
+fi

--- a/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
@@ -1,12 +1,16 @@
 #!/bin/sh
 {{/* vim: set ft=gotmpl */ -}}
-# -u bail on unset vars
 # -e bail on pipefail
-set -eu
+set -e
 
-if [[ -z "${CHEZMOI_WORKING_TREE}" ]]; then
-    echo "Error, \$CHEZMOI_WORKING_TREE must be set. Please only run this script via chezmoi"
-    exit 1
+
+if [ -z "${CHEZMOI_WORKING_TREE}" ]; then
+  echo "Error, \$CHEZMOI_WORKING_TREE must be set. Please only run this script via chezmoi" >&2
+  exit 1
+fi
+if [ "${CHEZMOI_COMMAND}" != "init" ]; then
+  [ "${CHEZMOI_VERBOSE:-0}" -eq "1" ] && echo "Skip github .ssh/known_hosts bootstrap - \$CHEZMOI_COMMAND must be 'init'" >&2
+  exit 0
 fi
 
 {{/* Only add github.com SSH pubkeys on first bootstrap run */ -}}

--- a/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_00-bootstrap-github-known_hosts.sh.tmpl
@@ -1,4 +1,5 @@
 #!/bin/sh
+{{/* vim: set ft=gotmpl */ -}}
 # -u bail on unset vars
 # -e bail on pipefail
 set -eu
@@ -7,10 +8,10 @@ if [[ -z "${CHEZMOI_WORKING_TREE}" ]]; then
     echo "Error, \$CHEZMOI_WORKING_TREE must be set. Please only run this script via chezmoi"
     exit 1
 fi
-{{- /* vim: set ft=gotmpl */ -}}
-{{- /* Only add github.com SSH pubkeys on first bootstrap run */ -}}
+
+{{/* Only add github.com SSH pubkeys on first bootstrap run */ -}}
 {{- /* Do not modify pre-existing ~/.ssh/known_hosts */ -}}
-{{- $sshDir := joinPath .chezmoi.destDir ".ssh" -}}
+{{- $sshDir := joinPath (.chezmoi.destDir | toString) ".ssh" -}}
 {{- $sshKnownHosts := joinPath $sshDir "known_hosts.modify_test" -}}
 if [ ! -e "{{ $sshKnownHosts }}" ]; then
   if [ ! -d "{{ $sshDir }}" ] ; then
@@ -18,8 +19,8 @@ if [ ! -e "{{ $sshKnownHosts }}" ]; then
     chmod 0700 "{{ $sshDir }}"
   fi
   cat >>{{ $sshKnownHosts }}<<-EOKH
-{{-   if stat (joinPath .chezmoi.cacheDir "github-meta-api") -}}
-{{-     $gitKeys := get (include (joinPath .chezmoi.cacheDir "github-meta-api") | fromJson) "ssh_keys" -}}
+{{    if stat (joinPath (.chezmoi.cacheDir | toString) "github-meta-api") -}}
+{{-     $gitKeys := get (include (joinPath (.chezmoi.cacheDir | toString) "github-meta-api") | fromJson) "ssh_keys" -}}
 {{      range $gitKeys }}github.com {{ . }}
 {{      end -}}
 {{-   else -}}

--- a/.chezmoiscripts/run_onchange_after_09-bat-theme-cache.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_09-bat-theme-cache.sh.tmpl
@@ -1,33 +1,38 @@
 #!/bin/bash
 
-{{- if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes") | or (stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes")) }}
+{{- if lookPath "bat" }}
+{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes") | or (stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes")) }}
 ## themes
-{{- if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes") }}
-{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Dark-Dracula-Theme") }}
+{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes") }}
+{{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Dark-Dracula-Theme") }}
 # Dark-Dracula-Theme sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Dark-Dracula-Theme") "rev-parse" "HEAD" "--" }}
-{{-   end }}
-{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Matcha-Dark") }}
+{{-     end }}
+{{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Matcha-Dark") }}
 # Matcha-Dark sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Matcha-Dark") "rev-parse" "HEAD" "--" }}
-{{-   end }}
-{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "sublime-snazzy") }}
+{{-     end }}
+{{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "sublime-snazzy") }}
 # sublime-snazzy sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "sublime-snazzy") "rev-parse" "HEAD" "--" }}
-{{-   end }}
-{{- else }}
+{{-     end }}
+{{-   else }}
 # none
-{{- end }}
+{{-   end }}
 ## syntaxes
-{{- if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes") }}
-{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "ASL-Syntax-Highlight") }}
+{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes") }}
+{{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "ASL-Syntax-Highlight") }}
 # ASL-Syntax-Highlight sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "ASL-Syntax-Highlight") "rev-parse" "HEAD" "--" }}
-{{-   end }}
-{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "Nftables") }}
+{{-     end }}
+{{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "Nftables") }}
 # Nftables sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "Nftables") "rev-parse" "HEAD" "--" }}
-{{-   end }}
-{{- else }}
+{{-     end }}
+{{-   else }}
 # none
-{{- end }}
+{{-   end }}
 
 bat cache --build
-{{- else }}
+{{-   else }}
 # no-op - {{ joinPath .chezmoi.homeDir ".config" "bat" "themes" }} or {{ joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" }} did not exist!
+{{-   end }}
+{{- else }}
+# no-op - bat not found on PATH
+echo "$0: WARN: bat not found on PATH - $PATH"
 {{- end }}

--- a/.chezmoiscripts/run_onchange_after_09-bat-theme-cache.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_09-bat-theme-cache.sh.tmpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 {{- if lookPath "bat" }}
 {{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes") | or (stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes")) }}

--- a/.chezmoiscripts/run_onchange_after_09-bat-theme-cache.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_09-bat-theme-cache.sh.tmpl
@@ -1,11 +1,33 @@
 #!/bin/bash
 
+{{- if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes") | or (stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes")) }}
 ## themes
-# Dark-Dracula-Theme sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Dark-Dracula-Theme") "rev-parse" "HEAD" }}
-# Matcha-Dark sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Matcha-Dark") "rev-parse" "HEAD" }}
-# sublime-snazzy sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "sublime-snazzy") "rev-parse" "HEAD" }}
+{{- if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes") }}
+{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Dark-Dracula-Theme") }}
+# Dark-Dracula-Theme sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Dark-Dracula-Theme") "rev-parse" "HEAD" "--" }}
+{{-   end }}
+{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Matcha-Dark") }}
+# Matcha-Dark sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Matcha-Dark") "rev-parse" "HEAD" "--" }}
+{{-   end }}
+{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "sublime-snazzy") }}
+# sublime-snazzy sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "sublime-snazzy") "rev-parse" "HEAD" "--" }}
+{{-   end }}
+{{- else }}
+# none
+{{- end }}
 ## syntaxes
-# ASL-Syntax-Highlight sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "ASL-Syntax-Highlight") "rev-parse" "HEAD" }}
-# Nftables sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "Nftables") "rev-parse" "HEAD" }}
+{{- if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes") }}
+{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "ASL-Syntax-Highlight") }}
+# ASL-Syntax-Highlight sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "ASL-Syntax-Highlight") "rev-parse" "HEAD" "--" }}
+{{-   end }}
+{{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "Nftables") }}
+# Nftables sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "Nftables") "rev-parse" "HEAD" "--" }}
+{{-   end }}
+{{- else }}
+# none
+{{- end }}
 
 bat cache --build
+{{- else }}
+# no-op - {{ joinPath .chezmoi.homeDir ".config" "bat" "themes" }} or {{ joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" }} did not exist!
+{{- end }}

--- a/.chezmoiscripts/run_onchange_after_09-bat-theme-cache.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_09-bat-theme-cache.sh.tmpl
@@ -5,13 +5,13 @@
 ## themes
 {{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes") }}
 {{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Dark-Dracula-Theme") }}
-# Dark-Dracula-Theme sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Dark-Dracula-Theme") "rev-parse" "HEAD" "--" }}
+# Dark-Dracula-Theme sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Dark-Dracula-Theme") "rev-parse" "HEAD" }}
 {{-     end }}
 {{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Matcha-Dark") }}
-# Matcha-Dark sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Matcha-Dark") "rev-parse" "HEAD" "--" }}
+# Matcha-Dark sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "Matcha-Dark") "rev-parse" "HEAD" }}
 {{-     end }}
 {{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "themes" "sublime-snazzy") }}
-# sublime-snazzy sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "sublime-snazzy") "rev-parse" "HEAD" "--" }}
+# sublime-snazzy sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "themes" "sublime-snazzy") "rev-parse" "HEAD" }}
 {{-     end }}
 {{-   else }}
 # none
@@ -19,10 +19,10 @@
 ## syntaxes
 {{-   if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes") }}
 {{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "ASL-Syntax-Highlight") }}
-# ASL-Syntax-Highlight sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "ASL-Syntax-Highlight") "rev-parse" "HEAD" "--" }}
+# ASL-Syntax-Highlight sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "ASL-Syntax-Highlight") "rev-parse" "HEAD" }}
 {{-     end }}
 {{-     if stat (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "Nftables") }}
-# Nftables sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "Nftables") "rev-parse" "HEAD" "--" }}
+# Nftables sha: {{ output "git" "-C" (joinPath .chezmoi.homeDir ".config" "bat" "syntaxes" "Nftables") "rev-parse" "HEAD" }}
 {{-     end }}
 {{-   else }}
 # none

--- a/.chezmoiscripts/run_onchange_after_09-update-desktop-database.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_09-update-desktop-database.sh.tmpl
@@ -5,5 +5,5 @@
 {{- if lookPath "update-desktop-database" }}
 update-desktop-database --verbose "${XDG_DATA_HOME:-$HOME/.local/share}/applications"
 {{- else }}
-echo "$0: WARN: update-desktop-database not found"
+echo "$0: WARN: update-desktop-database not found on PATH - $PATH"
 {{- end }}

--- a/.chezmoiscripts/run_onchange_after_09-update-desktop-database.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_09-update-desktop-database.sh.tmpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # chrome-unstable-gpu.desktop  hash: {{ include "private_dot_local/private_share/private_applications/chrome-unstable-gpu.desktop" | sha256sum }}
 

--- a/.chezmoiscripts/run_onchange_after_09-update-desktop-database.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_09-update-desktop-database.sh.tmpl
@@ -2,4 +2,8 @@
 
 # chrome-unstable-gpu.desktop  hash: {{ include "private_dot_local/private_share/private_applications/chrome-unstable-gpu.desktop" | sha256sum }}
 
+{{- if lookPath "update-desktop-database" }}
 update-desktop-database --verbose "${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+{{- else }}
+echo "$0: WARN: update-desktop-database not found"
+{{- end }}

--- a/dot_config/calcurse/caldav/config.tmpl
+++ b/dot_config/calcurse/caldav/config.tmpl
@@ -6,8 +6,11 @@
 # Alternatively, if using ~/.calcurse, create a new directory at
 # ~/.calcurse/caldav/ and copy this file to ~/.calcurse/caldav/config and adjust
 # the configuration file below.
-{{- $lpResults := ( printf "calcurse-caldav-%s - Google CalDAV Client" .chezmoi.hostname | lastpass) -}}
-{{- $lpItem := index $lpResults 0 }}
+{{- $lpItem := false }}
+{{- if lookPath "lpass" -}}
+{{-   $lpResults := ( printf "calcurse-caldav-%s - Google CalDAV Client" .chezmoi.hostname | lastpass) -}}
+{{-   $lpItem := index $lpResults 0 }}
+{{- end }}
 
 [General]
 # Path to the calcurse binary that is used for importing/exporting items.
@@ -21,6 +24,8 @@ Hostname = apidata.googleusercontent.com
 # path following your host name in the URL.
 {{- if $lpItem }}
 Path = /caldav/v2/{{ index (regexSplit ":" (regexFind "^email:.*" $lpItem.note.notes | trim) -1) 1 | trim }}/events/
+{{- else }}
+#Path = /path/to/calendar/on/the/server/
 {{- end }}
 
 # Type of authentication to use. Must be "basic" or "oauth2"
@@ -72,6 +77,10 @@ Verbose = Yes
 # CREATED: {{ $lpItem.note.creationDate | trim | toDate "January,02,2006" | date "2006-01-02" }}
 ClientID = {{ $lpItem.note.clientID | trim }}
 ClientSecret = {{ $lpItem.note.clientsecret | trim }}
+{- else }}
+#[OAuth2]
+#ClientID = your_client_id
+#ClientSecret = your_client_secret
 {{- end }}
 
 # Scope of access for API calls. Synchronization requires read/write.

--- a/dot_config/gh/hosts.yml.tmpl
+++ b/dot_config/gh/hosts.yml.tmpl
@@ -1,7 +1,7 @@
+{{- if lookPath "lpass" -}}
 github.com:
     user: {{ .githubuser }}
     git_protocol: ssh
-{{- if lookPath "lpass" -}}
 {{- $lpResults := ( printf "GitHub: gh - GitHub token - %s" .chezmoi.hostname | lastpass) -}}
 {{-   if $lpResults }}{{ $lpItem := index $lpResults 0 }}
 {{-     if ne .chezmoi.os "darwin" | and $lpItem }}

--- a/dot_config/private_hub.tmpl
+++ b/dot_config/private_hub.tmpl
@@ -1,8 +1,9 @@
+{{- if lookPath "lpass" -}}
 github.com:
 - user: {{ .githubuser }}
-{{- with (index ( printf "hub - GitHub token - %s" .chezmoi.hostname | lastpass) 0) -}}
-{{- $token_fullname_split_slice := (regexSplit " - " .note.notes -1) -}}
-{{- $last_idx := sub (len $token_fullname_split_slice) 1 }}
+{{-   with (index ( printf "hub - GitHub token - %s" .chezmoi.hostname | lastpass) 0) -}}
+{{-     $token_fullname_split_slice := (regexSplit " - " .note.notes -1) -}}
+{{-     $last_idx := sub (len $token_fullname_split_slice) 1 }}
   # {{ .note.name | trim }}
   # Regen token name:
   #   echo "hub - $(date +'%Y-%m-%d %H:%M:%S %z') - $(hostname) - {{ index $token_fullname_split_slice $last_idx | trim }}"
@@ -11,4 +12,5 @@ github.com:
   # EXPIRES: {{ .note.expiryDate | trim | toDate "January,02,2006" | date "2006-01-02" }}
   oauth_token: {{ .note.secretAPIKey | trim | quote }}
   protocol: https
+{{-   end }}
 {{- end }}

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -94,10 +94,12 @@
 	required = true
 [bash-it]
 	hide-status = 1
+{{- if ne (index .chezmoi.args 1) "init" }}
 [url "git@github.com:"]
 	insteadOf = https://github.com/
 [url "git+ssh://{{ .launchpaduser }}@git.launchpad.net/"]
 	insteadof = lp:
+{{- end }}
 [pull]
 	rebase = false
 [init]

--- a/private_dot_ssh/modify_private_known_hosts
+++ b/private_dot_ssh/modify_private_known_hosts
@@ -1,0 +1,17 @@
+{{- /* chezmoi:modify-template */ -}}
+{{- /* Only add github.com SSH pubkeys on first bootstrap run */ -}}
+{{- if .chezmoi.stdin -}}
+{{- /* Do not modify pre-existing ~/.ssh/known_hosts */ -}}
+{{-   .chezmoi.stdin }}
+{{- else -}}
+{{-   if stat (joinPath .chezmoi.cacheDir "github-meta-api") -}}
+{{-     $gitKeys := get (include (joinPath .chezmoi.cacheDir "github-meta-api") | fromJson) "ssh_keys" -}}
+{{      range $gitKeys }}github.com {{ . }}
+{{      end -}}
+{{-   else -}}
+{{- /* If API metadata was unavailable, use latest static keys as of 2025-07-03 */ -}}
+github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+{{    end -}}
+{{  end -}}


### PR DESCRIPTION
- **.chezmoiscripts/09-bat-theme-cache.sh: Short-circuit template logic if dirs don't exist**
- **.chezmoiscripts/09-update-desktop-database.sh: Skip and warn if update-desktop-database not found**
- **.chezmoiscripts/09-bat-theme-cache.sh: Skip & warn if bat not found**
- **.chezmoiscripts/09-update-desktop-database.sh: Print script execution PATH in warning**
- **.chezmoiscripts/09-bat-theme-cache.sh: Fix git rev-parse command errors**
- **.chezmoiscripts/*.sh: Use POSIX /bin/sh (avoid bootstrap depending on bash)**
- **.chezmoiexternal.yaml.tmpl: Add OFFLINE env var to skip externals + reindent & fix newlines**
- **.chezmoiexternal.yaml.tmpl: Gather github ssh pubkeys from metadata API**
- **.ssh/known_hosts: Add github.com initial SSH pubkeys on first bootstrap run only**
- **github known_hosts: Try using run_once before_ script due to chicken-egg issue**
- **github known_hosts: Fix newline chomping & convert vars to string for joinPath**
- **github known_hosts: Turn off test mode**
- **.gitconfig: Disable git SSH during chezmoi init (bootstrap)**
- **github known_hosts: Use POSIX-compatible [ tests & STDERR for verbose messages**
- **github known_hosts: Add comments for source & date of github keys**
- **.config/{gh,hub,calcurse}: Omit secrets in template rendering if lpass not found**
