### PR TITLE
fix ps4 prompt define tail fzf debug

### DIFF
--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -33,7 +33,7 @@ if [ "${-//[^x]/}" = "x" ]; then
           ;;
       *zsh)
           # shellcheck disable=SC2154
-          export PS4='${EPOCHREALTIME} (${(%):-%N}:${LINENO}): ${funcstack[1]:+${funcstack[1]}(): }' ;
+          export PS4='%D{%s.%N} (${(%):-%N}:%i): ${funcstack[1]:+${funcstack[1]}(): }' ;
           setopt prompt_subst
           ;;
   esac

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -1,0 +1,40 @@
+
+# shellcheck shell=sh
+# Function to detect the current shell
+# Heuristics needed. See: https://stackoverflow.com/q/3327013/645491
+detect_shell() {
+    # Check for shell-specific environment variables
+    if [ -n "$BASH" ]; then
+        echo "bash"
+    elif [ -n "$ZSH_NAME" ]; then
+        echo "zsh"
+    elif [ -n "$KSH_VERSION" ]; then
+        echo "ksh"
+    elif [ -n "$version" ]; then
+        echo "tcsh"
+    elif [ -n "$PS3" ] && [ -z "$PS4" ]; then
+        echo "ksh"
+    elif [ "$0" = "-sh" ] || [ "$0" = "sh" ]; then
+        echo "sh"
+    else
+        # Fallback: use process name
+        command ps -p "$$" -o comm=
+    fi
+}
+
+# Detect the current shell
+CURRENT_SHELL="$(detect_shell)"
+
+if [ "${-//[^x]/}" = "x" ]; then
+# Set PS4 for Bash or Zsh
+  case "$CURRENT_SHELL" in
+      *bash)
+          export PS4='+ $(date "+%s.%N") (${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+          ;;
+      *zsh)
+          # shellcheck disable=SC2154
+          export PS4='${EPOCHREALTIME} (${(%):-%N}:${LINENO}): ${funcstack[1]:+${funcstack[1]}(): }' ;
+          setopt prompt_subst
+          ;;
+  esac
+fi

--- a/dot_config/zsh/config.d/tail-fzf.zsh
+++ b/dot_config/zsh/config.d/tail-fzf.zsh
@@ -1,5 +1,18 @@
-#!/bin/bash
-PS4='+ $(date "+%s.%N") (${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+#!/bin/zsh
+# shellcheck shell=bash
+# Set PS4 for Bash or Zsh
+if [[ "$TAIL_FZF_DEBUG" == 'true' ]]; then
+  case "$SHELL" in
+      */bash)
+          PS4='+ $(date "+%s.%N") (${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+          ;;
+      */zsh)
+          # shellcheck disable=SC2154
+          PS4='${EPOCHREALTIME} (${(%):-%N}:${LINENO}): ${funcstack[1]:+${funcstack[1]}(): }'
+          ;;
+  esac
+  set -x
+fi
 
 # This script provides a way to interactively filter a log stream using fzf.
 # Each user-facing function is a wrapper around the _fzf_tail_mode function,

--- a/dot_config/zsh/config.d/tail-fzf.zsh
+++ b/dot_config/zsh/config.d/tail-fzf.zsh
@@ -1,18 +1,5 @@
 #!/bin/zsh
 # shellcheck shell=bash
-# Set PS4 for Bash or Zsh
-if [[ "$TAIL_FZF_DEBUG" == 'true' ]]; then
-  case "$SHELL" in
-      */bash)
-          PS4='+ $(date "+%s.%N") (${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-          ;;
-      */zsh)
-          # shellcheck disable=SC2154
-          PS4='${EPOCHREALTIME} (${(%):-%N}:${LINENO}): ${funcstack[1]:+${funcstack[1]}(): }'
-          ;;
-  esac
-  set -x
-fi
 
 # This script provides a way to interactively filter a log stream using fzf.
 # Each user-facing function is a wrapper around the _fzf_tail_mode function,


### PR DESCRIPTION
- **.config/zsh: tail-fzf: Only define PS4 when TAIL_FZF_DEBUG=true & support Bash + Zsh**
- **.config/{zsh,profile.d}: Move PS4 prompt setup for Bash/Zsh to profile.d**
- **.config/profile.d: Use % expansion for time/lineno**
