### PR TITLE
profile d fixes

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -31,6 +31,9 @@ README.md
 {{ if not (lookPath "makoctl") -}}
 .config/mako
 {{ end -}}
+{{ if not (lookPath "tex") -}}
+.config/profile.d/08-texlive.sh
+{{ end -}}
 {{ if not (lookPath "tmux") -}}
 .config/tmux
 {{ end -}}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -151,6 +151,9 @@ Library/Application Support/Mozilla/NativeMessagingHosts/gpgmejson.json
 {{ if not (lookPath "qt6ct") -}}
 .config/qt6ct
 {{ end -}}
+{{ if not (isExecutable (joinPath .chezmoi.homeDir ".qlty" "bin" "qlty")) -}}
+.config/profile.d/06-qlty-path.sh
+{{ end -}}
 {{- /* Omit makoctl imv/mpv helper utils if not installed */ -}}
 {{ if not (lookPath "makoctl") -}}
 {{   if not (lookPath "imv") -}}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -22,6 +22,9 @@ README.md
 {{ if not (lookPath "foot") -}}
 .config/foot
 {{ end -}}
+{{ if not (lookPath "lpass") -}}
+.config/05-lpass-settings.sh
+{{ end -}}
 {{ if not (lookPath "nwg-wrapper") -}}
 .config/nwg-wrapper
 {{ end -}}

--- a/dot_config/profile.d/executable_00-wayland.sh
+++ b/dot_config/profile.d/executable_00-wayland.sh
@@ -17,7 +17,7 @@ export ELECTRON_OZONE_PLATFORM_HINT=wayland
 
 # Disable hardware cursors. This might fix issues with
 # disappearing cursors
-if systemd-detect-virt -q; then
+if command -v systemd-detect-virt 1>/dev/null 2>&1 && systemd-detect-virt -q; then
     # if the system is running inside a virtual machine, disable hardware cursors
     export WLR_NO_HARDWARE_CURSORS=1
 fi

--- a/dot_config/profile.d/executable_00-xdg-data-dirs.sh
+++ b/dot_config/profile.d/executable_00-xdg-data-dirs.sh
@@ -1,0 +1,2 @@
+export XDG_DATA_DIRS="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS}"
+

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -82,6 +82,8 @@ if [ "${-//[^x]/}" = "x" ]; then
           #export PS4='%D{%s.%N} (%x:%i): %2(e.${(%)%N:#x}(%).): %N  ${funcstack[1]}' ;
           #export PS4='%D{%s.%N} (%x:%i): %2(e|${(%)==funcstack[1]:#${(%%)_null_:-%x}}()|): %N  ${funcstack[@]} -- ' ;
           export PS4='%D{%s.%N} (%x:%i): %%N= ${(%)_percentN_:-%N} %%x= ${(%)_null_:-%x} ##--> ${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}} <-- (): late %%N= %N -- '$'\n''    ${funcstack[@]} -- ' ;
+          export _clear_300='                                                                                                                                                                                                                                                                                                            '$'\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b'
+          export PS4='%D{%s.%N} (%x:%i): '$'\n''${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}%{'$'\e[300D'''${_clear_300}'%}%{'$'\b''%}  %1(V.%1v():.) ' ;
           setopt prompt_subst
           ;;
   esac

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -80,7 +80,7 @@ if [ "${-//[^x]/}" = "x" ]; then
       *zsh)
           # shellcheck disable=SC2154
           # export PS4='%D{%s.%N} (%x:%i): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v().%35<…<%N(%))  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
-          export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}(%x:%i) %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v%{()%G%}.%35<…<%N) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
+          export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}('$'\e]8;;void://file/''%x:%i:0'$'\a''%x:%i'$'\e]8;;\a'') %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v%{()%G%}.%35<…<%N) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
           setopt prompt_subst
           ;;
   esac

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -79,8 +79,8 @@ if [ "${-//[^x]/}" = "x" ]; then
           ;;
       *zsh)
           # shellcheck disable=SC2154
-          # export PS4='%D{%s.%N} (%x:%i): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v().%35<…<%N(%))  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
-          export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}('$'\e]8;;void://file/''%x:%i:0'$'\a''%x:%i'$'\e]8;;\a'') %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].%{%G%}) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v%{()%G%}.%35<…<%N) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
+          # export PS4='%D{%s.%N} (%x:%I): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v:%i().%35<…<%N(%):%i)  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
+          export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}('$'\e]8;;void://file/''%x:%I:0'$'\a''%x:%I'$'\e]8;;\a'') %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].%{%G%}) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v:%i%{()%G%}.%35<…<%N:%i) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
           setopt prompt_subst
           ;;
   esac

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -83,8 +83,14 @@ if [ "${-//[^x]/}" = "x" ]; then
               # shellcheck disable=SC2154
               export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}('$'\e]8;;void://file/''%x:%I:0'$'\a''%x:%I'$'\e]8;;\a'') %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].%{%G%}) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v:%i%{()%G%}.%35<…<%N:%i) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
           else
-              # shellcheck disable=SC2154
-              export PS4='%D{%s.%N} (%x:%I): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v:%i().%35<…<%N(%):%i)  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
+              if [ "$COLORTERM" = "truecolor" ] || [ "$COLORTERM" = 24bit ] || [ "$(\command tput colors 2> /dev/null)" -ge 255 ] || \command infocmp -1 | grep -q -iE 'colors.*0x100'; then
+                  # shellcheck disable=SC2154
+                  export PS4='%F{239}%D{%s.%N}%f (%B%F{075}%x:%I%f%b): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %B%F{003}%2(L.%{%G%}%{󰶻 %G%}[%L].)%f%b '$'\n''%B%F{149}  %1(V.%1v:%i().%35<…<%N(%):%i)%f%b  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
+              elif [ "$COLORTERM" = 8bit ] || [ "$(\command tput colors 2> /dev/null)" -lt 255 -a "$(\command tput colors 2> /dev/null)" -ge 8 ] || \command infocmp -1 | grep -q -iE 'colors.*0x008'; then
+                  export PS4='%B%F{008}%D{%s.%N}%f%b (%B%x:%I%b): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %B%F{003}%2(L.%{%G%}%{󰶻 %G%}[%L].)%f%b '$'\n''%{ '$'\b''%}  %B%F{002}%1(V.%1v:%i().%35<…<%N(%):%i)%f%b  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
+              else
+                  export PS4='%B%D{%s.%N}%b (%B%x:%I%b): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %B%2(L.%{%G%}%{󰶻 %G%}[%L].)%b '$'\n''%{ '$'\b''%}  %B%1(V.%1v:%i().%35<…<%N(%):%i)%b  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
+              fi
           fi
           setopt prompt_subst
           ;;

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -79,7 +79,8 @@ if [ "${-//[^x]/}" = "x" ]; then
           ;;
       *zsh)
           # shellcheck disable=SC2154
-          export PS4='%D{%s.%N} (%x:%i): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v().%35<…<%N(%))  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
+          # export PS4='%D{%s.%N} (%x:%i): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v().%35<…<%N(%))  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
+          export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}(%x:%i) %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v%{()%G%}.%35<…<%N) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
           setopt prompt_subst
           ;;
   esac

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -80,7 +80,7 @@ if [ "${-//[^x]/}" = "x" ]; then
       *zsh)
           # shellcheck disable=SC2154
           # export PS4='%D{%s.%N} (%x:%i): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v().%35<…<%N(%))  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
-          export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}('$'\e]8;;void://file/''%x:%i:0'$'\a''%x:%i'$'\e]8;;\a'') %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v%{()%G%}.%35<…<%N) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
+          export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}('$'\e]8;;void://file/''%x:%i:0'$'\a''%x:%i'$'\e]8;;\a'') %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].%{%G%}) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v%{()%G%}.%35<…<%N) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
           setopt prompt_subst
           ;;
   esac

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -64,6 +64,7 @@ detect_shell() {
         # Fallback: use process name
         detect_ps
         eval $shell_detect_cmd
+        #command ps -p "$$" -o comm=
     fi
 }
 
@@ -78,7 +79,9 @@ if [ "${-//[^x]/}" = "x" ]; then
           ;;
       *zsh)
           # shellcheck disable=SC2154
-          export PS4='%D{%s.%N} (${(%):-%N}:%i): ${funcstack[1]:+${funcstack[1]}(): }' ;
+          #export PS4='%D{%s.%N} (%x:%i): %2(e.${(%)%N:#x}(%).): %N  ${funcstack[1]}' ;
+          #export PS4='%D{%s.%N} (%x:%i): %2(e|${(%)==funcstack[1]:#${(%%)_null_:-%x}}()|): %N  ${funcstack[@]} -- ' ;
+          export PS4='%D{%s.%N} (%x:%i): %%N= ${(%)_percentN_:-%N} %%x= ${(%)_null_:-%x} ##--> ${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}} <-- (): late %%N= %N -- '$'\n''    ${funcstack[@]} -- ' ;
           setopt prompt_subst
           ;;
   esac

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -79,11 +79,7 @@ if [ "${-//[^x]/}" = "x" ]; then
           ;;
       *zsh)
           # shellcheck disable=SC2154
-          #export PS4='%D{%s.%N} (%x:%i): %2(e.${(%)%N:#x}(%).): %N  ${funcstack[1]}' ;
-          #export PS4='%D{%s.%N} (%x:%i): %2(e|${(%)==funcstack[1]:#${(%%)_null_:-%x}}()|): %N  ${funcstack[@]} -- ' ;
-          export PS4='%D{%s.%N} (%x:%i): %%N= ${(%)_percentN_:-%N} %%x= ${(%)_null_:-%x} ##--> ${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}} <-- (): late %%N= %N -- '$'\n''    ${funcstack[@]} -- ' ;
-          export _clear_300='                                                                                                                                                                                                                                                                                                            '$'\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b'
-          export PS4='%D{%s.%N} (%x:%i): '$'\n''${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}%{'$'\e[300D'''${_clear_300}'%}%{'$'\b''%}  %1(V.%1v():.) ' ;
+          export PS4='%D{%s.%N} (%x:%i): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v().%35<…<%N(%))  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
           setopt prompt_subst
           ;;
   esac

--- a/dot_config/profile.d/executable_00a-set-debug-prompt.sh
+++ b/dot_config/profile.d/executable_00a-set-debug-prompt.sh
@@ -78,9 +78,14 @@ if [ "${-//[^x]/}" = "x" ]; then
           export PS4='+ $(date "+%s.%N") (${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
           ;;
       *zsh)
-          # shellcheck disable=SC2154
-          # export PS4='%D{%s.%N} (%x:%I): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v:%i().%35<…<%N(%):%i)  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
-          export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}('$'\e]8;;void://file/''%x:%I:0'$'\a''%x:%I'$'\e]8;;\a'') %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].%{%G%}) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v:%i%{()%G%}.%35<…<%N:%i) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
+          # Use color + p10k powerline glyphs if interactive
+          if [ "${-//[^i]/}" = "i" ]; then
+              # shellcheck disable=SC2154
+              export PS4=$'\n''%b%f%K{239}%D{%s.%N} %k%K{018}%F{239}%{ %G%}%f%k%K{018} %{󰈮 %G%}('$'\e]8;;void://file/''%x:%I:0'$'\a''%x:%I'$'\e]8;;\a'') %k%K{221}%F{018}%{ %G%}%f%k%F{black}%K{221} %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,)%2(L.%{%G%}%{󰶻 %G%}[%B%L%b].%{%G%}) %k%f%F{221}%{ %G%}%f '$'\n''%{ '$'\b''%}%B%K{030}  %{ %G%}%1(V.%1v:%i%{()%G%}.%35<…<%N:%i) %k%b%F{030}%{ %G%}%f %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)%B%F{249}' ;
+          else
+              # shellcheck disable=SC2154
+              export PS4='%D{%s.%N} (%x:%I): %(0l,%0<${psvar[1]::=}${psvar[1]::=${${(%)__percentN__:-%N}:#${(%)_filePercent_x_:-%x}}}<,) %2(L.%{%G%}%{󰶻 %G%}[%L].) '$'\n''%{ '$'\b''%}  %1(V.%1v:%i().%35<…<%N(%):%i)  %(0l,%0<${psvar::=${psvar:#${_eval_::=(eval)}}}<,)' ;
+          fi
           setopt prompt_subst
           ;;
   esac

--- a/dot_config/profile.d/executable_02-gpg-agent.sh.tmpl
+++ b/dot_config/profile.d/executable_02-gpg-agent.sh.tmpl
@@ -1,0 +1,7 @@
+{{ if (eq .chezmoi.os "linux") -}}
+export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/gnupg/S.gpg-agent.ssh"
+{{ else if (eq .chezmoi.os "darwin") -}}
+export SSH_AUTH_SOCK="$HOME/.gnupg/S.gpg-agent.ssh"
+{{ else if (eq .chezmoi.os "windows") -}}
+export SSH_AUTH_SOCK=\\.\pipe\openssh-ssh-agent
+{{ end -}}

--- a/dot_config/profile.d/executable_05-golang-path.sh
+++ b/dot_config/profile.d/executable_05-golang-path.sh
@@ -1,0 +1,3 @@
+export GOPATH="$HOME/src/pub/go"
+export PATH="$GOPATH/bin:$PATH"
+

--- a/dot_config/profile.d/executable_05-lpass-settings.sh.tmpl
+++ b/dot_config/profile.d/executable_05-lpass-settings.sh.tmpl
@@ -1,0 +1,73 @@
+{{ $copy_cmd := "" -}}
+{{ $clear_cmd := "" -}}
+{{ $pinentry_cmd := "" -}}
+{{ if (eq .chezmoi.os "linux") | and ((lookPath "wayland-scanner") | or (eq .xdg_session_type "wayland")) -}}
+{{   $copy_cmd = lookPath "wl-copy" -}}
+{{   $clear_cmd = cat (lookPath "wl-copy") "--clear" -}}
+{{   $pinentry_cmd = lookPath "pinentry-gnome3" -}}
+{{ else if (eq .chezmoi.os "linux") -}}
+{{   $copy_cmd = cat (lookPath "xclip") "-selection clipboard -in -sensitive" -}}
+{{   if lookPath "pinentry-gnome3" -}}
+{{     $pinentry_cmd = lookPath "pinentry-gnome3" -}}
+{{   else if lookPath "pinentry-curses" -}}
+{{     $pinentry_cmd = lookPath "pinentry-curses" -}}
+{{   else if lookPath "pinentry-tty" -}}
+{{     $pinentry_cmd = lookPath "pinentry-tty" -}}
+{{   else if lookPath "pinentry" -}}
+{{     $pinentry_cmd = lookPath "pinentry" -}}
+{{   end -}}
+{{ else if (eq .chezmoi.os "darwin") -}}
+{{   if lookPath "pbcopy" -}}
+{{     $copy_cmd = lookPath "pbcopy" -}}
+{{     $clear_cmd = cat "echo -n '' |" (lookPath "pbcopy") -}}
+{{   end -}}
+{{   if isExecutable "/usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac" -}}
+{{     $pinentry_cmd = "/usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac" -}}
+{{   else if lookPath "pinentry-curses" -}}
+{{     $pinentry_cmd = lookPath "pinentry-curses" -}}
+{{   else if lookPath "pinentry-tty" -}}
+{{     $pinentry_cmd = lookPath "pinentry-tty" -}}
+{{   else if lookPath "pinentry" -}}
+{{     $pinentry_cmd = lookPath "pinentry" -}}
+{{   end -}}
+{{ else if (eq .chezmoi.os "windows") -}}
+{{   if lookPath "clip.exe" -}}
+{{     $copy_cmd = cat (lookPath "perl") "-pe 'chomp if eof' |" (lookPath "clip.exe") -}}
+{{     $clear_cmd = cat "echo off |" (lookPath "clip.exe") -}}
+{{   end -}}
+{{   if isExecutable (joinPath "C:" "Program Files (x86)" "Gpg4win" "bin" "pinentry.exe") -}}
+{{     $pinentry_cmd = joinPath "C:" "Program Files (x86)" "Gpg4win" "bin" "pinentry.exe" -}}
+{{   else -}}
+{{     $pinentry_cmd = lookPath "pinentry.exe" -}}
+{{   end -}}
+{{ else -}}
+{{   if lookPath "xclip" -}}
+{{     $copy_cmd = cat (lookPath "xclip") "-selection clipboard -in -sensitive" -}}
+{{   end -}}
+{{   if lookPath "pinentry-gnome3" -}}
+{{     $pinentry_cmd = lookPath "pinentry-gnome3" -}}
+{{   else if lookPath "pinentry-curses" -}}
+{{     $pinentry_cmd = lookPath "pinentry-curses" -}}
+{{   else if lookPath "pinentry-tty" -}}
+{{     $pinentry_cmd = lookPath "pinentry-tty" -}}
+{{   else if lookPath "pinentry" -}}
+{{     $pinentry_cmd = lookPath "pinentry" -}}
+{{   end -}}
+{{ end -}}
+{{ if (eq .chezmoi.os "windows") -}}
+{{   if $copy_cmd | and $clear_cmd -}}
+export LPASS_CLIPBOARD_COMMAND='{{ $copy_cmd }} && timeout 30 && {{ $clear_cmd }}'
+{{   end -}}
+{{   if $pinentry_cmd -}}
+export LPASS_PINENTRY={{ $pinentry_cmd }}
+{{   end -}}
+{{ else -}}
+{{   if $copy_cmd | and $clear_cmd -}}
+export LPASS_CLIPBOARD_COMMAND='{{ $copy_cmd }} && ( sleep 30 && {{ $clear_cmd }}) & disown'
+{{   else if $copy_cmd -}}
+export LPASS_CLIPBOARD_COMMAND='{{ $copy_cmd }}'
+{{   end -}}
+{{   if $pinentry_cmd -}}
+export LPASS_PINENTRY={{ $pinentry_cmd }}
+{{   end -}}
+{{ end -}}

--- a/dot_config/profile.d/executable_06-cargo-path.sh
+++ b/dot_config/profile.d/executable_06-cargo-path.sh
@@ -1,0 +1,2 @@
+export PATH="${HOME}/.cargo/bin:$PATH"
+

--- a/dot_config/profile.d/executable_06-opencv.sh
+++ b/dot_config/profile.d/executable_06-opencv.sh
@@ -1,0 +1,3 @@
+# Disable warnings by OpenCV
+export OPENCV_LOG_LEVEL=ERROR
+

--- a/dot_config/profile.d/executable_06-qlty-path.sh
+++ b/dot_config/profile.d/executable_06-qlty-path.sh
@@ -1,0 +1,4 @@
+# qlty
+export QLTY_INSTALL="$HOME/.qlty"
+export PATH="$QLTY_INSTALL/bin:$PATH"
+

--- a/dot_config/profile.d/executable_08-texlive.sh
+++ b/dot_config/profile.d/executable_08-texlive.sh
@@ -1,0 +1,2 @@
+export TEXMFDIST=/usr/share/texmf-dist
+export TEXMFLOCAL=/usr/local/share/texmf:/usr/share/texmf

--- a/dot_config/profile.d/executable_09-home-local-bin.sh
+++ b/dot_config/profile.d/executable_09-home-local-bin.sh
@@ -1,0 +1,2 @@
+export PATH="$HOME/.local/bin:$PATH"
+

--- a/dot_config/zsh/config.d/01-run-help-as-function.zsh
+++ b/dot_config/zsh/config.d/01-run-help-as-function.zsh
@@ -1,0 +1,2 @@
+(( $+aliases[run-help] )) && unalias run-help
+autoload -Uz run-help

--- a/dot_config/zsh/config.d/03-print-xterm-colors.zsh
+++ b/dot_config/zsh/config.d/03-print-xterm-colors.zsh
@@ -1,0 +1,22 @@
+#!/usr/bin/zsh
+# Author: James Cuzella <james.cuzella@lyraphase.com>
+# License: GNU AGPLv3
+
+# Copyright (C) © 🄯  2025 James Cuzella
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>.
+
+# print-xterm-256-colors: Print xterm 256 color demo with Zsh expansion
+function print-xterm-256-colors() {
+  for i in {0..255}; do print -Pn "%K{$i} %k%F{$i}${(l:3::0:)i}%f " "${${(M)$((i%6)):#3}:+\\n}"; done
+}


### PR DESCRIPTION
- **.config/profile.d/00-wayland.sh: skip systemd-detect-virt if not installed**
- **.config/profile.d/00a-set-debug-prompt.sh: Handle ps variants & CLI flag detection**
- **.config/zsh: Override run-help widget with fxn**
- **.config/profile.d/00a-set-debug-prompt.sh: Save WIP zsh PS4 prompt**
- **.config/profile.d: 2-line smart PS4**
- **.config/profile.d: zsh PS4: Silence psvar hack, add SHLVL indicator & truncated %N fallback**
- **.config/profile.d: zsh PS4: prettify with colors, NF icons & p10k/powerline glyphs**
- **.config/profile.d: zsh PS4: Add OSC 8 file links via void://**
- **.config/profile.d: zsh PS4: Always print NF $ icon for SHLVL segment**
- **.config/profile.d: zsh PS4: Fix file URI line numbers '%I' & add fxn/file numbers '%i'**
- Add all other untracked `profile.d` items from backlog
