### PR TITLE
idle inhibitors

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -112,6 +112,9 @@ Library/Application Support/Mozilla/NativeMessagingHosts/gpgmejson.json
 {{   if not (lookPath "swayidle-conf") -}}
 .config/sway/idle.yaml
 {{   end -}}
+{{   if not (lookPath "systemd-inhibit") | or (not (lookPath "waybar-signal")) | or (not (lookPath "rofi")) -}}
+.local/bin/inhibit-idle
+{{   end -}}
 {{   if not (lookPath "dragon-drop") -}}
 .config/sway/config.d/04-dragon-drop.conf
 .config/sway/definitions.d/05-dragon-drop.conf

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -213,6 +213,9 @@ Library/Application Support/Mozilla/NativeMessagingHosts/gpgmejson.json
 {{   if not (lookPath "chrome") | or (not (lookPath "google-chrome")) | or (not (findExecutable "chrome" (list "opt/google/chrome" ".local/bin"))) -}}
 .local/bin/google-chrome-vulkan-intel-kabylake-sorta-works.sh
 {{   end -}}
+{{   if not (lookPath "/usr/lib/systemd/user/idlehack.service") | or (not (lookPath "idlehack")) -}}
+.config/systemd/user/default.target.wants/idlehack.service
+{{   end -}}
 {{ end -}}
 {{ if not (eq .osFamily "linux-arch") | or (not (lookPath "yay")) -}}
 .config/zsh/config.d/03-yay-fzf-search.zsh

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -108,6 +108,9 @@ Library/Application Support/Mozilla/NativeMessagingHosts/gpgmejson.json
 .config/sov
 .config/nwg-wrapper/sway-time.sh
 .config/nwg-wrapper/timezones.css
+{{   if not (lookPath "swayidle-conf") -}}
+.config/sway/idle.yaml
+{{   end -}}
 {{   if not (lookPath "dragon-drop") -}}
 .config/sway/config.d/04-dragon-drop.conf
 .config/sway/definitions.d/05-dragon-drop.conf

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -108,6 +108,7 @@ Library/Application Support/Mozilla/NativeMessagingHosts/gpgmejson.json
 .config/sov
 .config/nwg-wrapper/sway-time.sh
 .config/nwg-wrapper/timezones.css
+.local/bin/idle_inhibitor_windows
 {{   if not (lookPath "swayidle-conf") -}}
 .config/sway/idle.yaml
 {{   end -}}

--- a/dot_config/swayidle/config.example
+++ b/dot_config/swayidle/config.example
@@ -1,0 +1,7 @@
+idlehint 240
+timeout  240 'light -G > /tmp/brightness && light -S 10' resume 'light -S $([ -f /tmp/brightness ] && cat /tmp/brightness || echo 100%)'
+timeout  300 'exec swaylock --daemonize'
+timeout  600 'swaymsg "output * power off"' resume 'swaymsg "output * power on"'
+timeout  600 'sudo pkill -USR2 cec-dpms'  resume 'sudo pkill -USR1 cec-dpms'
+before-sleep 'playerctl pause'
+before-sleep 'exec swaylock --daemonize & sleep 2'

--- a/dot_config/swayidle/config.example
+++ b/dot_config/swayidle/config.example
@@ -1,7 +1,0 @@
-idlehint 240
-timeout  240 'light -G > /tmp/brightness && light -S 10' resume 'light -S $([ -f /tmp/brightness ] && cat /tmp/brightness || echo 100%)'
-timeout  300 'exec swaylock --daemonize'
-timeout  600 'swaymsg "output * power off"' resume 'swaymsg "output * power on"'
-timeout  600 'sudo pkill -USR2 cec-dpms'  resume 'sudo pkill -USR1 cec-dpms'
-before-sleep 'playerctl pause'
-before-sleep 'exec swaylock --daemonize & sleep 2'

--- a/dot_config/systemd/user/default.target.wants/symlink_idlehack.service
+++ b/dot_config/systemd/user/default.target.wants/symlink_idlehack.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/user/idlehack.service

--- a/private_dot_local/bin/executable_idle_inhibitor_windows
+++ b/private_dot_local/bin/executable_idle_inhibitor_windows
@@ -1,0 +1,2 @@
+#!/bin/sh
+swaymsg -t get_tree |jq 'recurse(.nodes[]) |= {fullscreen_mode, nodes, focus, focused, id, name, app_id, inhibit_idle, idle_inhibitors} | select(.inhibit_idle == true)'

--- a/private_dot_local/bin/executable_idle_inhibitor_windows
+++ b/private_dot_local/bin/executable_idle_inhibitor_windows
@@ -1,2 +1,2 @@
 #!/bin/sh
-swaymsg -t get_tree |jq 'recurse(.nodes[]) |= {fullscreen_mode, nodes, focus, focused, id, name, app_id, inhibit_idle, idle_inhibitors} | select(.inhibit_idle == true)'
+swaymsg -t get_tree | jq 'recurse(.nodes[]) |= {fullscreen_mode, nodes, focus, focused, id, name, app_id, inhibit_idle, idle_inhibitors} | select(.inhibit_idle == true)'

--- a/private_dot_local/bin/executable_inhibit-idle
+++ b/private_dot_local/bin/executable_inhibit-idle
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+
+status() {
+    ps -ef | grep -v grep | grep -m 1 -q "systemd-inhibit --what=idle"
+}
+
+inhibit() {
+    systemd-inhibit --what=idle --who=swayidle-inhibit --why=commanded --mode=block sleep $1 &
+    waybar-signal idle
+}
+
+case $1'' in
+'interactive')
+    MINUTES=$(echo -e "1\n10\n15\n20\n30\n45\n60\n90\n120\n180\n240\n300\n360\n420\n480\ninfinity" | rofi -l 17 -dmenu -p "Select how many minutes to inhibit idle:")
+    case $MINUTES in
+        ''|*[!0-9]*) : ;; # Pass through string 'infinity'
+        *) MINUTES=$((MINUTES * 60)) ;;
+    esac
+    inhibit ${MINUTES}
+    ;;
+'off')
+    pkill -f "systemd-inhibit --what=idle" || true
+    waybar-signal idle
+    ;;
+esac
+
+#Returns data for Waybar
+if status; then
+    class="on"
+    text="Inhibiting idle (Mid click to clear)"
+else
+    class="off"
+    text="Idle not inhibited"
+fi
+
+printf '{"alt":"%s","tooltip":"%s"}\n' "$class" "$text"

--- a/private_dot_local/bin/executable_inhibit-idle
+++ b/private_dot_local/bin/executable_inhibit-idle
@@ -1,22 +1,22 @@
 #!/usr/bin/env sh
 
 status() {
-    ps -ef | grep -v grep | grep -m 1 -q "systemd-inhibit --what=idle"
+    pgrep --count --full 'systemd-inhibit --what=idle' 2>/dev/null 1>&2
 }
 
 inhibit() {
-    systemd-inhibit --what=idle --who=swayidle-inhibit --why=commanded --mode=block sleep $1 &
+    systemd-inhibit --what=idle --who=swayidle-inhibit --why=commanded --mode=block sleep "$1" &
     waybar-signal idle
 }
 
-case $1'' in
+case "$1"'' in
 'interactive')
-    MINUTES=$(echo -e "1\n10\n15\n20\n30\n45\n60\n90\n120\n180\n240\n300\n360\n420\n480\ninfinity" | rofi -l 17 -dmenu -p "Select how many minutes to inhibit idle:")
-    case $MINUTES in
+    MINUTES=$(printf "1\n10\n15\n20\n30\n45\n60\n90\n120\n180\n240\n300\n360\n420\n480\ninfinity" | rofi -l 17 -dmenu -p "Select how many minutes to inhibit idle:")
+    case "$MINUTES" in
         ''|*[!0-9]*) : ;; # Pass through string 'infinity'
         *) MINUTES=$((MINUTES * 60)) ;;
     esac
-    inhibit ${MINUTES}
+    inhibit "${MINUTES}"
     ;;
 'off')
     pkill -f "systemd-inhibit --what=idle" || true


### PR DESCRIPTION
- **.config/systemd/user: Add idlehack.service to default.target.wants**
- **.config/systemd/user: Omit idlehack.service default.target.wants symlink if idlehack or target not installed**
- **.chezmoiignore: Omit swayidle-conf idle.yaml config if not installed**
- **.local/bin/inhibit-idle: Add modified inhibit-idle helper script for waybar widget**
- **.local/bin/inhibit-idle: Fix all shellcheck warnings**
- **.local/bin/idle_inhibitor_windows: Add sway helper script to list windows inhibiting idle**
- **.config/swayidle: Track example config for future reference**
- **.config/swayidle: Remove swayidle example config for now b/c we use swayidle-conf YAML config**
