### PR TITLE
.config/sway: Add cec-dpms resume lock screen keybinding (XF86HomePage)

### DIFF
--- a/dot_config/sway/config.d/02-cec-dpms-resume-lock.conf
+++ b/dot_config/sway/config.d/02-cec-dpms-resume-lock.conf
@@ -1,0 +1,5 @@
+# Copyright (C) © 🄯  2023-2025 James Cuzella
+# This program is free software: See LICENSE
+
+# def: ~/.config/sway/definitions.d/02-cec-dpms-resume-lock.conf
+bindsym --locked --no-repeat XF86HomePage exec $cec_dpms_resume

--- a/dot_config/sway/definitions.d/02-cec-dpms-resume-lock.conf
+++ b/dot_config/sway/definitions.d/02-cec-dpms-resume-lock.conf
@@ -1,0 +1,7 @@
+# Copyright (C) © 🄯  2023-2025 James Cuzella
+# This program is free software: See LICENSE
+
+# bind: ~/.config/sway/config.d/02-cec-dpms-resume-lock.conf
+### Sway lock command + keybinding to wake display
+set $cec_dpms_resume 'sudo pkill -USR1 cec-dpms'
+


### PR DESCRIPTION
Notes:

- Added keybinding for signaling cec-dpms to wake & switch input
- Useful for when screen did not respond to swaylock resume signal, or when
  secondary TV display's remote turns off the primay display due to shared IR
  codes.
