### PR TITLE
cec dpms sway wake resume keybinding

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -270,6 +270,10 @@ Library/Application Support/Mozilla/NativeMessagingHosts/gpgmejson.json
 .config/systemd/user/graphical-session.target.wants/cec-dpms@dev-ttyACM0.service
 .config/systemd/user/cec-dpms@.service
 {{ end -}}
+{{ if not (eq .chezmoi.os "linux") | or (not (lookPath "sway")) | or (not (lookPath "cec-dpms")) -}}
+.config/sway/config.d/02-cec-dpms-resume-lock.conf
+.config/sway/definitions.d/02-cec-dpms-resume-lock.conf
+{{ end -}}
 {{   if not (eq .chezmoi.os "linux") | or (not (lookPath "chrome") | or (not (lookPath "google-chrome"))) | or (not (findExecutable "chrome" (list "opt/google/chrome" ".local/bin"))) -}}
 .local/bin/google-chrome-vulkan-intel-kabylake-sorta-works.sh
 {{   end -}}


### PR DESCRIPTION
- **.config/sway: Omit cec-dpms resume lock screen keybinding files if not installed**
