### PR TITLE
.config/sway: Rebind waybar hide/show to Control+Alt+b

### DIFF
--- a/dot_config/sway/config.d/96-waybar-config.conf
+++ b/dot_config/sway/config.d/96-waybar-config.conf
@@ -2,7 +2,7 @@
 # Used: bindsym --to-code $mod+Shift+b  in /etc/sway/modes/default
 $unbindsym $mod+Shift+b
 ## Action // Toggle Waybar ## L_Alt+Shift+b
-$bindsym $alt_mod+Shift+b exec pkill -x -SIGUSR1 waybar
+$bindsym $ctrl_mod+$alt_mod+Shift+b exec pkill -x -SIGUSR1 waybar
 
 # Waybar supports only subset of bar config:
 # id, mode, hidden_state

--- a/dot_config/sway/definitions.d/00-bb-set-keybind-vars.conf
+++ b/dot_config/sway/definitions.d/00-bb-set-keybind-vars.conf
@@ -1,0 +1,4 @@
+# Copyright (C) © 🄯  2023-2025 James Cuzella
+# This program is free software: See LICENSE
+set $ctrl_mod Control
+set $numlock Mod2


### PR DESCRIPTION
Rebind to: <kbd>Control</kbd>+<kbd>Alt</kbd>+<kbd>b</kbd>

Reason: Conflicted with VSCode GitLens keybinding for `Toggle Git CodeLens`