### PR TITLE
.config/sway: Unbind XF86PowerOff & rely on systemd-logind instead

### DIFF
--- a/dot_config/sway/config.d/03-override-sleep-shutdown.conf
+++ b/dot_config/sway/config.d/03-override-sleep-shutdown.conf
@@ -1,0 +1,10 @@
+# Unbind the default shutdown key
+# Used: bindsym --to-code XF86PowerOff exec $shutdown
+#  in /etc/sway/modes/default
+$unbindsym XF86PowerOff
+# systemd-logind will handle these keys instead
+# Default is: HandlePowerKey=poweroff
+# Default was: HandleSuspendKey=suspend
+# Changed to: HandleSuspendKey=lock
+# Default was: HandleSuspendKeyLongPress=hibernate
+# Changed to: HandleSuspendKeyLongPress=suspend


### PR DESCRIPTION
After testing, it seems that `systemd-logind` preempts keybindings for these:

| Key name       | `/etc/systemd/logind.conf` default binding |
|----------------|-----------|
| `XF86PowerOff` | `HandlePowerKey=poweroff` |
| `XF86Sleep` | `HandleSuspendKey=suspend` |

External to `chezmoi`, `/etc/systemd/logind.conf` changed:


| Key name       | `/etc/systemd/logind.conf` new binding |
|----------------|-----------|
| `XF86PowerOff` | `HandlePowerKey=poweroff` |
| `XF86Sleep` | `HandleSuspendKey=lock` |
| `XF86Sleep` | `HandleSuspendKeyLongPress=suspend` |