### PR TITLE
feat als fzf accepted next cmd

### DIFF
--- a/dot_config/zsh/config.d/aliases-fzf.zsh
+++ b/dot_config/zsh/config.d/aliases-fzf.zsh
@@ -54,7 +54,11 @@ __aliases() {
     __view_alias_code | \
     bat --plain --language bash --color always | \
     perl -0777 -pe 's/\n/\0/g' | \
-    fzf --read0 --ansi --reverse --multi --highlight-line
+    fzf --read0 \
+        --ansi \
+        --reverse \
+        --multi \
+        --highlight-line
 }
 
 # Browse shell alias definitions with fzf

--- a/dot_config/zsh/config.d/aliases-fzf.zsh
+++ b/dot_config/zsh/config.d/aliases-fzf.zsh
@@ -58,7 +58,9 @@ __aliases() {
         --ansi \
         --reverse \
         --multi \
-        --highlight-line
+        --highlight-line \
+        --delimiter '=' \
+        --accept-nth 1
 }
 
 # Browse shell alias definitions with fzf

--- a/dot_config/zsh/config.d/aliases-fzf.zsh
+++ b/dot_config/zsh/config.d/aliases-fzf.zsh
@@ -65,8 +65,15 @@ __aliases() {
 
 # Browse shell alias definitions with fzf
 als() {
+  local _accepted_item
   # Filter out alias namespace clutter using grep by default
-  __aliases
+  _accepted_item="$(__aliases)"
+
+  # If the user didn't cancel fzf (string is not empty)
+  if [[ -n "$_accepted_item" ]]; then
+    # Push the command into the next prompt buffer
+    print -z "$_accepted_item"
+  fi
 }
 
 # Browse ALL shell alias definitions with fzf


### PR DESCRIPTION
- **config/zsh/config.d: style: Reflow `als` `fzf` `__aliases()` fxn**
- **config/zsh/config.d: feat: `als` `fzf` use delimiter '`=`', output accepted item's 1st field**
- **config/zsh/config.d: feat: `als` `fzf` types accepted alias into Zle next cmd prompt**
