### PR TITLE
.config/foot: Fix foot v1.26.0 colors config schema deprecations

### DIFF
--- a/dot_config/foot/foot.ini.tmpl
+++ b/dot_config/foot/foot.ini.tmpl
@@ -2,9 +2,11 @@
 # vim: ft=dosini
 {{ $footclient_version_out := output "/bin/sh" "-c" "footclient --version" -}}
 {{ $footclient_version := regexReplaceAll "^footclient version: ([0-9.]+) .*" $footclient_version_out "${1}" | trim | toString -}}
-{{ $supports_colors_cursor_schema := semverCompare ">1.22.x" $footclient_version -}}
+{{ $supports_colors_cursor_schema := semverCompare ">1.22.x < 1.26.0" $footclient_version -}}
+{{ $supports_colors_light_dark_schema := semverCompare ">=1.26.0" $footclient_version -}}
 ## footclient version: {{ $footclient_version }}
 ## supports colors.cursor: {{ $supports_colors_cursor_schema }}
+## supports colors-{dark,light}: {{ $supports_colors_light_dark_schema }}
 {{/* $cpuinfo_model := output "/bin/sh" "-c" "grep -iE '^Model' /proc/cpuinfo" */ -}}
 {{ $is_raspi := regexMatch "Raspberry Pi" (output "/bin/sh" "-c" "grep -iE '^Model' /proc/cpuinfo") -}}
 {{/* ## cpuinfo Model: {{ $cpuinfo_model */ -}}
@@ -85,7 +87,7 @@ lines=100000
 # blink=no
 # beam-thickness=1.5
 # underline-thickness=<font underline thickness>
-{{ if not $supports_colors_cursor_schema -}}
+{{ if not $supports_colors_cursor_schema | and (not $supports_colors_light_dark_schema) -}}
 color= 141a1b 2eb398 # Matcha Teal
 #color= 141a1b eeeeee
 #color= 141a1b bd93f9 # Purple
@@ -101,11 +103,22 @@ color= 141a1b 2eb398 # Matcha Teal
 #include=/usr/share/foot/themes/material-design
 include=/home/trinitronx/.config/foot/themes/manjaro-sway-default
 
-{{ if $supports_colors_cursor_schema -}}
+{{ if $supports_colors_cursor_schema | or $supports_colors_light_dark_schema -}}
+{{-   if $supports_colors_light_dark_schema }}
+[colors-dark]
+{{-   else  }}
 [colors]
+{{-   end }}
 cursor= 141a1b 2eb398 # Matcha Teal
 #cursor= 141a1b eeeeee
 #cursor= 141a1b bd93f9 # Purple
+{{-   if $supports_colors_light_dark_schema }}
+#[colors-light]
+#cursor= 141a1b 2eb398 # Matcha Teal
+{{-   else  }}
+#[colors2]
+#cursor= 141a1b 2eb398 # Matcha Teal
+{{-   end }}
 {{- end }}
 
 [key-bindings]

--- a/dot_config/foot/themes/manjaro-sway-default.tmpl
+++ b/dot_config/foot/themes/manjaro-sway-default.tmpl
@@ -2,13 +2,21 @@
 {{ $footclient_version_out := output "/bin/sh" "-c" "footclient --version" -}}
 {{ $footclient_version := regexReplaceAll "^footclient version: ([0-9.]+) .*" $footclient_version_out "${1}" | trim | toString -}}
 {{ $supports_colors_cursor_schema := semverCompare ">1.22.x" $footclient_version -}}
+{{ $supports_colors_light_dark_schema := semverCompare ">=1.26.0" $footclient_version -}}
+{{ $supports_colors_light_dark_schema := semverCompare ">=1.26.0" $footclient_version -}}
 ## footclient version: {{ $footclient_version }}
 ## supports colors.cursor: {{ $supports_colors_cursor_schema }}
+## supports colors-{dark,light}: {{ $supports_colors_light_dark_schema }}
+
+{{- if $supports_colors_light_dark_schema }}
+[colors-dark]
+{{- else  }}
 [colors]
+{{- end }}
 alpha=0.9
 foreground=eeeeee
 background=141a1b
-{{ if $supports_colors_cursor_schema -}}
+{{ if $supports_colors_cursor_schema | or $supports_colors_light_dark_schema -}}
 #cursor= 141a1b bd93f9 # Purple
 cursor= 141a1b 2eb398 # Matcha Teal
 {{ end -}}


### PR DESCRIPTION
Reference: https://codeberg.org/dnkl/foot/releases/tag/1.26.0
