### PR TITLE
configure foot desktop notifications

### DIFF
--- a/dot_config/foot/foot.ini.tmpl
+++ b/dot_config/foot/foot.ini.tmpl
@@ -71,10 +71,11 @@ visual=yes
 # command-focused=no
 
 [desktop-notifications]
+command=foot-notify-xdg-activation.sh "${app-id}" "${category}" --urgency "${urgency}" --expire-time "${expire-time}" --hint "STRING:image-path:${icon}" --hint "BOOLEAN:suppress-sound:${muted}" --hint "STRING:sound-name:${sound-name}" --replace-id "${replace-id}" "${action-argument}" --print-id -- "${title} ${body}"
 # command=notify-send --wait --app-name ${app-id} --icon ${app-id} --category ${category} --urgency ${urgency} --expire-time ${expire-time} --hint STRING:image-path:${icon} --hint BOOLEAN:suppress-sound:${muted} --hint STRING:sound-name:${sound-name} --replace-id ${replace-id} ${action-argument} --print-id -- ${title} ${body}
-# command-action-argument=--action ${action-name}=${action-label}
+command-action-argument=--action "${action-name}=${action-label}"
 # close=""
-# inhibit-when-focused=yes
+inhibit-when-focused=yes
 
 
 [scrollback]

--- a/dot_config/foot/foot.ini.tmpl
+++ b/dot_config/foot/foot.ini.tmpl
@@ -70,6 +70,13 @@ visual=yes
 # command=
 # command-focused=no
 
+[desktop-notifications]
+# command=notify-send --wait --app-name ${app-id} --icon ${app-id} --category ${category} --urgency ${urgency} --expire-time ${expire-time} --hint STRING:image-path:${icon} --hint BOOLEAN:suppress-sound:${muted} --hint STRING:sound-name:${sound-name} --replace-id ${replace-id} ${action-argument} --print-id -- ${title} ${body}
+# command-action-argument=--action ${action-name}=${action-label}
+# close=""
+# inhibit-when-focused=yes
+
+
 [scrollback]
 #lines=10000
 lines=100000

--- a/dot_config/foot/foot.ini.tmpl
+++ b/dot_config/foot/foot.ini.tmpl
@@ -71,9 +71,9 @@ visual=yes
 # command-focused=no
 
 [desktop-notifications]
-command=foot-notify-xdg-activation.sh "${app-id}" "${category}" --urgency "${urgency}" --expire-time "${expire-time}" --hint "STRING:image-path:${icon}" --hint "BOOLEAN:suppress-sound:${muted}" --hint "STRING:sound-name:${sound-name}" --replace-id "${replace-id}" "${action-argument}" --print-id -- "${title} ${body}"
+command=foot-notify-xdg-activation.sh --wait --app-name ${app-id} --icon ${app-id} --category ${category} --urgency ${urgency} --expire-time ${expire-time} --hint STRING:image-path:${icon} --hint BOOLEAN:suppress-sound:${muted} --hint STRING:sound-name:${sound-name} --replace-id ${replace-id} ${action-argument} --print-id -- ${title} ${body}
 # command=notify-send --wait --app-name ${app-id} --icon ${app-id} --category ${category} --urgency ${urgency} --expire-time ${expire-time} --hint STRING:image-path:${icon} --hint BOOLEAN:suppress-sound:${muted} --hint STRING:sound-name:${sound-name} --replace-id ${replace-id} ${action-argument} --print-id -- ${title} ${body}
-command-action-argument=--action "${action-name}=${action-label}"
+command-action-argument=--action ${action-name}=${action-label}
 # close=""
 inhibit-when-focused=yes
 

--- a/dot_config/foot/foot.ini.tmpl
+++ b/dot_config/foot/foot.ini.tmpl
@@ -65,7 +65,7 @@ workers=8
 [bell]
 system=yes
 # urgent=no
-# notify=no
+notify=yes
 visual=yes
 # command=
 # command-focused=no

--- a/private_dot_local/private_share/sway/scripts/executable_foot-notify-xdg-activation.sh
+++ b/private_dot_local/private_share/sway/scripts/executable_foot-notify-xdg-activation.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+app_id="$1"
+category="$2"
+urgency="$3"
+expire_time="$4"
+icon="$5"
+muted="$6"
+sound_name="$7"
+replace_id="$8"
+action_argument="$9"
+title="${10}"
+body="${11}"
+action_name="${12}"
+action_label="${13}"
+
+notify-send --wait \
+  --app-name "${app_id}" \
+  --icon "${app_id}" \
+  --category "${category}" \
+  --urgency "${urgency}" \
+  --expire-time "${expire_time}" \
+  --hint "STRING:image-path:${icon}" \
+  --hint "BOOLEAN:suppress-sound:${muted}" \
+  --hint "STRING:sound-name:${sound_name}" \
+  --replace-id "${replace_id}" "${action_argument}" \
+  --print-id -- "${title} ${body}" 1>/dev/null 2>&1
+# Output format - see "Window activation (focusing)" section: man 5 foot.ini
+echo "${action_name}"
+echo "xdgtoken=${XDG_TOKEN}"

--- a/private_dot_local/private_share/sway/scripts/executable_foot-notify-xdg-activation.sh
+++ b/private_dot_local/private_share/sway/scripts/executable_foot-notify-xdg-activation.sh
@@ -11,7 +11,7 @@ cleanup() { rm -f "$token_file"; }
 trap cleanup EXIT
 
 # Play sound
-paplay /usr/share/sounds/freedesktop/stereo/message.oga
+paplay /usr/share/sounds/freedesktop/stereo/message.oga 1>/dev/null 2>&1
 
 # Pass all arguments through to notify-send unchanged.
 # FD 3 captures the XDG activation token; stdout (ID + action) goes to foot.

--- a/private_dot_local/private_share/sway/scripts/executable_foot-notify-xdg-activation.sh
+++ b/private_dot_local/private_share/sway/scripts/executable_foot-notify-xdg-activation.sh
@@ -1,30 +1,23 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Wrapper around notify-send that captures the XDG activation token
+# and outputs it in the format foot expects (xdgtoken=TOKEN).
+#
+# notify-send writes the token to --activation-token-fd, not stdout.
+# This wrapper captures it via FD 3 and appends it to stdout for foot.
+set -eu
 
-app_id="$1"
-category="$2"
-urgency="$3"
-expire_time="$4"
-icon="$5"
-muted="$6"
-sound_name="$7"
-replace_id="$8"
-action_argument="$9"
-title="${10}"
-body="${11}"
-action_name="${12}"
-action_label="${13}"
+token_file="$(mktemp)"
+cleanup() { rm -f "$token_file"; }
+trap cleanup EXIT
 
-notify-send --wait \
-  --app-name "${app_id}" \
-  --icon "${app_id}" \
-  --category "${category}" \
-  --urgency "${urgency}" \
-  --expire-time "${expire_time}" \
-  --hint "STRING:image-path:${icon}" \
-  --hint "BOOLEAN:suppress-sound:${muted}" \
-  --hint "STRING:sound-name:${sound_name}" \
-  --replace-id "${replace_id}" "${action_argument}" \
-  --print-id -- "${title} ${body}" 1>/dev/null 2>&1
-# Output format - see "Window activation (focusing)" section: man 5 foot.ini
-echo "${action_name}"
-echo "xdgtoken=${XDG_TOKEN}"
+# Pass all arguments through to notify-send unchanged.
+# FD 3 captures the XDG activation token; stdout (ID + action) goes to foot.
+notify-send --activation-token-fd=3 "$@" 3>"$token_file"
+status=$?
+
+# Append the token line if one was received
+if [ -s "$token_file" ]; then
+    printf 'xdgtoken=%s\n' "$(cat "$token_file")"
+fi
+
+exit "$status"

--- a/private_dot_local/private_share/sway/scripts/executable_foot-notify-xdg-activation.sh
+++ b/private_dot_local/private_share/sway/scripts/executable_foot-notify-xdg-activation.sh
@@ -10,6 +10,9 @@ token_file="$(mktemp)"
 cleanup() { rm -f "$token_file"; }
 trap cleanup EXIT
 
+# Play sound
+paplay /usr/share/sounds/freedesktop/stereo/message.oga
+
 # Pass all arguments through to notify-send unchanged.
 # FD 3 captures the XDG activation token; stdout (ID + action) goes to foot.
 notify-send --activation-token-fd=3 "$@" 3>"$token_file"


### PR DESCRIPTION
- **.config/foot: Merge new desktop-notifications config section**
- **.config/foot: Configure foot desktop-notifications helper w/XDG activation protocol support**
- **.config/foot: Initial foot desktop-notifications helper w/XDG activation protocol support**
- **.config/foot: Refactor foot desktop-notifications helper for notify-send's XDG activation token via FD**
- **.config/foot: Turn on bell notifications**
- **.local/share/sway/scripts: Play notification sound for foot notifications**
