### PR TITLE
.chezmoiexternal.yaml.tmpl: Fix font checksum YAML format for chezmoi >= 2.59.0

### DIFF
--- a/.chezmoiexternal.yaml.tmpl
+++ b/.chezmoiexternal.yaml.tmpl
@@ -172,7 +172,8 @@
   exact: false
   private: true
   readonly: true
-  checksum.sha256: {{ (output "/bin/sh" "-c" $mesloChecksumCommand) | trim }}
+  checksum:
+    sha256: {{ (output "/bin/sh" "-c" $mesloChecksumCommand) | trim | quote }}
 {{ end -}}
 {{ if eq .chezmoi.os "darwin" | or (eq .chezmoi.os "linux" | and (not (glob "/usr/share/fonts/TTF/JetBrainsMonoNerdFontMono-*.ttf"))) -}}
 # Darwin OR (Linux AND non-existent fonts path): {{ glob "/usr/share/fonts/TTF/MesloLGS-NF-*.ttf" }}
@@ -187,5 +188,6 @@
   exact: false
   private: true
   readonly: true
-  checksum.sha256: {{ (output "/bin/sh" "-c" $jetBrainsMonoChecksumCommand) | trim }}
+  checksum:
+    sha256: {{ (output "/bin/sh" "-c" $jetBrainsMonoChecksumCommand) | trim | quote }}
 {{ end -}}


### PR DESCRIPTION
YAML parsing for this `checksum.sha256` field previously worked and is now
broken in current versions of chezmoi.

**Root cause:** chezmoi's `HexBytes` type (used for `checksum.sha256` / `sha384`
/ `sha512`) has a custom `UnmarshalYAML` that calls `strconv.Unquote()` on the
YAML value. That Go function requires the input to be a Go-style quoted string
literal (i.e. `"abc..."` with the quotes **_included_**). When we passed a bare
unquoted scalar, `strconv.Unquote` returns `strconv.ErrSyntax`, which printed as
"invalid syntax" with no line number, because the error comes from the field
decoder rather than the YAML parser.

**Fix:** pipe the templated value through quote so the rendered YAML contains a
quoted string:

    checksum:
      sha256: {{ (output "/bin/sh" "-c" $mesloChecksumCommand) | trim | quote }}

Quite a surprising chezmoi quirk. Most YAML schemas don't require quotes on hex
scalars, but looking at the chezmoi source code confirmed it.  Otherwise, this
should be valid YAML. I managed to track down the issue to
[`internal/chezmoi/hexbytes.go:L51-52`][1], where it calls the `UnmarshalYAML`
method.

The trigger commit is twpayne/chezmoi@e25d60b4 with comment
"chore: Use github.com/goccy/go-yaml instead of gopkg.in/yaml.v3" (2025-01-26).

The switch from gopkg.in/yaml.v3 to github.com/goccy/go-yaml added a new
`UnmarshalYAML([]byte)` method on `HexBytes` (the type backing every
`checksum.sha256` / `sha384` / `sha512` field). The new implementation pipes the
raw YAML scalar bytes through Go's `strconv.Unquote`, which requires Go-style
quotes around the value — so any unquoted hex string returns `strconv.ErrSyntax`
("invalid syntax").

Under the old `gopkg.in/yaml.v3` decoder, hex was just decoded as a plain scalar
string and unquoting wasn't involved, which is why your template worked on prior
versions.

So the version window is:

  - Works: ≤ v2.58.x (last good: v2.58.0, Dec 2024)
  - Broken (requires `| quote`): ≥ v2.59.0 (Jan 27, 2025)

Tested on `v2.70.3`, which is well past the boundary, and the `| quote` fix
works. Current chezmoi docs or examples don't mention this new quoting
requirement.  There likely were not any unit tests to detect a breaking change.

[1]: https://github.com/twpayne/chezmoi/blob/d23768bb941880bdf67b500d9b0b1d750906812c/internal/chezmoi/hexbytes.go#L51-L52
