### PR TITLE
merge vscode void configs

### DIFF
--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -61,7 +61,8 @@
     },
     "isort.args": [
       "--profile",
-      "black"
+      "black",
+      "--lines-after-import", "2"
     ],
     "flake8.ignorePatterns": [
       "**/site-packages/**/*.py",

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -301,6 +301,11 @@
     "sonarlint.analysisExcludesStandalone": "**/node_modules/**,**/vendor,**/__pycache__/**,**/site-packages/**,**/.void-editor/**",
     "sonarlint.focusOnNewCode": true,
     "sonarlint.output.showVerboseLogs": true,
+    "scss.lint.duplicateProperties": "warning",
+    "scss.lint.universalSelector": "warning",
+    "custom-language-properties": {
+      "scss.comments.lineComment": ""
+    },
     "amp.permissions": [
       {
         "tool": "Bash",

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -274,6 +274,8 @@
     },
     "shellformat.path": "/usr/bin/shfmt",
     "window.commandCenter": false,
+    "atlascode.jira.enabled": true,
+    "atlascode.bitbucket.enabled": true,
     "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
     "amp.permissions": [
       {

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -275,7 +275,7 @@
     "shellformat.path": "/usr/bin/shfmt",
     "window.commandCenter": false,
     "atlascode.jira.enabled": true,
-    "atlascode.bitbucket.enabled": true,
+    "atlascode.bitbucket.enabled": false,
     "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
     "amp.permissions": [
       {

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -5,6 +5,7 @@
         "GitHub.vscode-pull-request-github",
         "command line flag",
         "ms-python.python",
+        "ms-python.vscode-python-envs'",
         "GitHub.copilot-chat"
       ]
     },

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -241,6 +241,10 @@
     "solargraph.logLevel": "debug",
     "solargraph.useBundler": true,
     "solargraph.transport": "external",
+    "solargraph.externalServer": {
+      "host": "localhost",
+      "port": 7658
+    },
     "github.copilot.enable": {
       "*": true,
       "plaintext": false,

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -16,6 +16,7 @@
     "terminal.integrated.allowChords": false,
     "editor.fontLigatures": "'cv02', 'cv04', 'cv05', 'cv07', 'cv08', 'cv11', 'cv14', 'cv99', 'ss19', 'zero', 'calt', 'ss04', 'ss08', 'ss09', 'cv23'",
     "window.zoomLevel": 1,
+    "telemetry.telemetryLevel": "error",
     "redhat.telemetry.enabled": true,
     "sonarlint.disableTelemetry": true,
     "git.openRepositoryInParentFolders": "always",

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -67,6 +67,10 @@
       "**/usr/bin/*",
       "**/usr/local/bin/*"
     ],
+    "python.locator": "native",
+    "python.defaultInterpreterPath": "~/.pyenv/shims/python",
+    "python.useEnvironmentsExtension": true,
+    // "python-envs.defaultEnvManager": "ms-python.python:pyenv",
     "[python]": {
       "editor.formatOnSave": true,
       "editor.codeActionsOnSave": {
@@ -77,6 +81,24 @@
       "editor.defaultFormatter": "charliermarsh.ruff"
       // "editor.defaultFormatter": "ms-python.python"
     },
+    "python.experiments.enabled": true,
+    "python.experiments.optInto": [
+      "pythonTestAdapter"
+      // "pythonTerminalEnvVarActivation"
+    ],
+    "python.terminal.activateEnvironment": true,
+    "debugpy.debugJustMyCode": false,
+    "python.analysis.exclude": [
+      "**/node_modules",
+      "**/__pycache__",
+      "**/.git"
+      // "**/site-packages",
+      // "**/3rdparty_repositories",
+      // "**/usr/lib/python3.*/dist-packages",
+      // "**/usr/lib/python3.*/site-packages",
+      // "**/usr/local/lib/python3.*/dist-packages",
+      // "**/usr/local/lib/python3.*/site-packages"
+    ],
     "ruff.organizeImports": true,
     "ruff.exclude": [
       ".vscode/**/*.py",
@@ -242,13 +264,6 @@
     "solidity.telemetry": false,
     "gitlens.autolinks": [],
     "firedbg.showWelcome": false,
-    "python.experiments.optInto": [
-      "pythonTestAdapter",
-      "pythonTerminalEnvVarActivation"
-      // "pythonDebuggerAutoReload"
-    ],
-    "python.terminal.activateEnvironment": true,
-    "debugpy.debugJustMyCode": false,
     "[shellscript]": {
       "files.eol": "\n",
       "editor.formatOnSave": false,
@@ -260,7 +275,4 @@
     "shellformat.path": "/usr/bin/shfmt",
     "window.commandCenter": false,
     "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
-    "python.defaultInterpreterPath": "/bin/python",
-    "python.locator": "native",
-    "python.useEnvironmentsExtension": true
 }

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -250,7 +250,6 @@
     "gopls": {
       "ui.semanticTokens": true
     },
-    "mesonbuild.downloadLanguageServer": true,
     "cmake.pinnedCommands": [
       "workbench.action.tasks.configureTaskRunner",
       "workbench.action.tasks.runTask"
@@ -282,6 +281,8 @@
     "git.blame.editorDecoration.enabled": true,
     "gitlens.ai.model": "vscode",
     "files.autoSave": "afterDelay",
+    "mesonbuild.downloadLanguageServer": true,
+    "mesonbuild.linter.muon.enabled": true,
     "rubyLsp.formatter": "auto",
     "rubyLsp.featureFlags": {
       "fullTestDiscovery": false

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -236,6 +236,7 @@
     "remote.localPortHost": "allInterfaces",
     "remote.SSH.remoteServerListenOnSocket": true,
     "rubyTestExplorer.debugCommand": "bundle exec rdebug-ide",
+    "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
     "rubyTestExplorer.logpanel": true,
     "solargraph.logLevel": "debug",
     "solargraph.useBundler": true,
@@ -288,7 +289,6 @@
     "rubyLsp.rubyVersionManager": {
       "identifier": "rvm"
     },
-    "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
     "amp.permissions": [
       {
         "tool": "Bash",

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -281,7 +281,13 @@
     "git.blame.editorDecoration.enabled": true,
     "gitlens.ai.model": "vscode",
     "files.autoSave": "afterDelay",
-
+    "rubyLsp.formatter": "auto",
+    "rubyLsp.featureFlags": {
+      "fullTestDiscovery": false
+    },
+    "rubyLsp.rubyVersionManager": {
+      "identifier": "rvm"
+    },
     "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
     "amp.permissions": [
       {

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -17,6 +17,7 @@
     "editor.fontLigatures": "'cv02', 'cv04', 'cv05', 'cv07', 'cv08', 'cv11', 'cv14', 'cv99', 'ss19', 'zero', 'calt', 'ss04', 'ss08', 'ss09', 'cv23'",
     "window.zoomLevel": 1,
     "redhat.telemetry.enabled": true,
+    "sonarlint.disableTelemetry": true,
     "git.openRepositoryInParentFolders": "always",
     "evenBetterToml.formatter.alignComments": true,
     "evenBetterToml.formatter.alignEntries": true,

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -296,6 +296,10 @@
       "identifier": "rvm"
     },
     "testing.coverageToolbarEnabled": true,
+    "sonarlint.testFilePattern": "**/test/**,**/tests/**,**/*test,**/spec/**",
+    "sonarlint.analysisExcludesStandalone": "**/node_modules/**,**/vendor,**/__pycache__/**,**/site-packages/**,**/.void-editor/**",
+    "sonarlint.focusOnNewCode": true,
+    "sonarlint.output.showVerboseLogs": true,
     "amp.permissions": [
       {
         "tool": "Bash",

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -162,9 +162,6 @@
       "editor.semanticHighlighting.enabled": true, // Enable semantic highlighting
       "editor.formatOnType": true // Enable formatting while typing
     },
-    "yaml.schemas": {
-      "file://${userHome}/.vscode/extensions/atlassian.atlascode-4.0.13-universal/resources/schemas/pipelines-schema.json": "bitbucket-pipelines.yml"
-    },
     "gitlens.graph.dimMergeCommits": true,
     "gitlens.views.repositories.showIncomingActivity": true,
     "gitlens.graph.minimap.additionalTypes": [

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -280,6 +280,7 @@
     "git.autofetch": true,
     "git.blame.editorDecoration.enabled": true,
     "gitlens.ai.model": "vscode",
+    "files.autoSave": "afterDelay",
 
     "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
     "amp.permissions": [

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -276,6 +276,7 @@
     "window.commandCenter": false,
     "atlascode.jira.enabled": true,
     "atlascode.bitbucket.enabled": false,
+    "chat.mcp.discovery.enabled": true,
     "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
     "amp.permissions": [
       {

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -10,6 +10,7 @@
       ]
     },
     "window.titleBarStyle": "native",
+    "workbench.tree.enableStickyScroll": false,
     "workbench.colorTheme": "Default Dark Modern",
     "editor.fontFamily": "'JetBrainsMono Nerd Font Mono', 'JetBrainsMono Nerd Font', 'FiraCode Nerd Font Mono', 'Monoid Nerd Font Mono', 'Droid Sans Mono',  monospace, 'Droid Sans Fallback'",
     "terminal.integrated.fontFamily": "'JetBrainsMono Nerd Font', monospace",

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -277,6 +277,10 @@
     "atlascode.jira.enabled": true,
     "atlascode.bitbucket.enabled": false,
     "chat.mcp.discovery.enabled": true,
+    "git.autofetch": true,
+    "git.blame.editorDecoration.enabled": true,
+    "gitlens.ai.model": "vscode",
+
     "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
     "amp.permissions": [
       {

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -294,6 +294,7 @@
     "rubyLsp.rubyVersionManager": {
       "identifier": "rvm"
     },
+    "testing.coverageToolbarEnabled": true,
     "amp.permissions": [
       {
         "tool": "Bash",

--- a/app_modified/.config/Code/User/settings.json
+++ b/app_modified/.config/Code/User/settings.json
@@ -275,4 +275,665 @@
     "shellformat.path": "/usr/bin/shfmt",
     "window.commandCenter": false,
     "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
+    "amp.permissions": [
+      {
+        "tool": "Bash",
+        "action": "ask",
+        "matches": {
+          "cmd": "*git*push*"
+        }
+      },
+      {
+        "tool": "mcp__*",
+        "action": "allow"
+      },
+      {
+        "tool": "read_mcp_resource",
+        "action": "allow"
+      },
+      {
+        "tool": "tb__*",
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": "/^(.*\\s+)?(bazel|ibazel)\\s+.*\\/\\/[^\\s]*.*$/"
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "ls",
+            "ls *",
+            "dir",
+            "dir *",
+            "cat *",
+            "head *",
+            "tail *",
+            "less *",
+            "more *",
+            "grep *",
+            "egrep *",
+            "fgrep *",
+            "tree",
+            "tree *",
+            "file *",
+            "wc *",
+            "pwd",
+            "stat *",
+            "du *",
+            "df *",
+            "ps *",
+            "top",
+            "htop",
+            "echo *",
+            "printenv *",
+            "id",
+            "which *",
+            "whereis *",
+            "date",
+            "cal *",
+            "uptime",
+            "free *",
+            "ping *",
+            "dig *",
+            "nslookup *",
+            "host *",
+            "netstat *",
+            "ss *",
+            "lsof *",
+            "ifconfig *",
+            "ip *",
+            "man *",
+            "info *",
+            "mkdir *",
+            "touch *",
+            "uname *",
+            "whoami",
+            "go version",
+            "go env *",
+            "go help *",
+            "cargo version",
+            "cargo --version",
+            "cargo help *",
+            "rustc --version",
+            "rustc --help",
+            "rustc --explain *",
+            "javac --version",
+            "javac -version",
+            "javac -help",
+            "javac --help",
+            "dotnet --info",
+            "dotnet --version",
+            "dotnet --help",
+            "dotnet help *",
+            "gcc --version",
+            "gcc -v",
+            "gcc --help",
+            "gcc -dumpversion",
+            "g++ --version",
+            "g++ -v",
+            "g++ --help",
+            "g++ -dumpversion",
+            "clang --version",
+            "clang --help",
+            "clang++ --version",
+            "clang++ --help",
+            "python -V",
+            "python --version",
+            "python -h",
+            "python --help",
+            "python3 -V",
+            "python3 --version",
+            "python3 -h",
+            "python3 --help",
+            "ruby -v",
+            "ruby --version",
+            "ruby -h",
+            "ruby --help",
+            "node -v",
+            "node --version",
+            "node -h",
+            "node --help",
+            "npm --help",
+            "npm --version",
+            "npm -v",
+            "npm help *",
+            "yarn --help",
+            "yarn --version",
+            "yarn -v",
+            "yarn help *",
+            "pnpm --help",
+            "pnpm --version",
+            "pnpm -v",
+            "pnpm help *",
+            "pytest -h",
+            "pytest --help",
+            "pytest --version",
+            "jest --help",
+            "jest --version",
+            "mocha --help",
+            "mocha --version",
+            "make --version",
+            "make --help",
+            "docker --version",
+            "docker --help",
+            "docker version",
+            "docker help *",
+            "git --version",
+            "git --help",
+            "git help *",
+            "git version"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "go test *",
+            "go run *",
+            "go build *",
+            "go vet *",
+            "go fmt *",
+            "go list *",
+            "cargo test *",
+            "cargo run *",
+            "cargo build *",
+            "cargo check *",
+            "cargo fmt *",
+            "cargo tree *",
+            "make -n *",
+            "make --dry-run *",
+            "mvn test *",
+            "mvn verify *",
+            "mvn dependency:tree *",
+            "gradle tasks *",
+            "gradle dependencies *",
+            "gradle properties *",
+            "dotnet test *",
+            "dotnet list *",
+            "python -c *",
+            "ruby -e *",
+            "node -e *",
+            "npm list *",
+            "npm ls *",
+            "npm outdated *",
+            "npm test*",
+            "npm run*",
+            "npm view *",
+            "npm info *",
+            "yarn list*",
+            "yarn ls *",
+            "yarn info *",
+            "yarn test*",
+            "yarn run *",
+            "yarn why *",
+            "pnpm list*",
+            "pnpm ls *",
+            "pnpm outdated *",
+            "pnpm test*",
+            "pnpm run *",
+            "pytest --collect-only *",
+            "jest --listTests *",
+            "jest --showConfig *",
+            "mocha --list *",
+            "git status*",
+            "git show *",
+            "git diff*",
+            "git grep *",
+            "git branch *",
+            "git tag *",
+            "git remote -v *",
+            "git rev-parse --is-inside-work-tree *",
+            "git rev-parse --show-toplevel *",
+            "git config --list *",
+            "git log *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "./gradlew *",
+            "./mvnw *",
+            "./build.sh *",
+            "./configure *",
+            "cmake *",
+            "./node_modules/.bin/tsc *",
+            "./node_modules/.bin/eslint *",
+            "./node_modules/.bin/prettier *",
+            "prettier *",
+            "./node_modules/.bin/tailwindcss *",
+            "./node_modules/.bin/tsx *",
+            "./node_modules/.bin/vite *",
+            "bun *",
+            "tsx *",
+            "vite *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            ".venv/bin/activate *",
+            ".venv/Scripts/activate *",
+            "source .venv/bin/activate *",
+            "source venv/bin/activate *",
+            "pip list *",
+            "pip show *",
+            "pip check *",
+            "pip freeze *",
+            "uv *",
+            "poetry show *",
+            "poetry check *",
+            "pipenv check *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "asdf list *",
+            "asdf current *",
+            "asdf which *",
+            "mise list *",
+            "mise current *",
+            "mise which *",
+            "mise use *",
+            "rbenv version *",
+            "rbenv versions *",
+            "rbenv which *",
+            "nvm list *",
+            "nvm current *",
+            "nvm which *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "./test*",
+            "./run_tests.sh *",
+            "./run_*_tests.sh *",
+            "vitest *",
+            "bundle exec rspec *",
+            "bundle exec rubocop *",
+            "rspec *",
+            "rubocop *",
+            "swiftlint *",
+            "clippy *",
+            "ruff *",
+            "black *",
+            "isort *",
+            "mypy *",
+            "flake8 *",
+            "bandit *",
+            "safety *",
+            "biome check *",
+            "biome format *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "rails server *",
+            "rails s *",
+            "bin/rails server *",
+            "bin/rails s *",
+            "flask run *",
+            "django-admin runserver *",
+            "python manage.py runserver *",
+            "uvicorn *",
+            "streamlit run *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "bin/rails db:status",
+            "bin/rails db:version",
+            "rails db:rollback *",
+            "rails db:status *",
+            "rails db:version *",
+            "alembic current *",
+            "alembic history *",
+            "bundle exec rails db:status",
+            "bundle exec rails db:version"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "docker ps *",
+            "docker images *",
+            "docker logs *",
+            "docker inspect *",
+            "docker info *",
+            "docker stats *",
+            "docker system df *",
+            "docker system info *",
+            "podman ps *",
+            "podman images *",
+            "podman logs *",
+            "podman inspect *",
+            "podman info *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "aws --version *",
+            "aws configure list *",
+            "aws sts get-caller-identity *",
+            "aws s3 ls *",
+            "gcloud config list *",
+            "gcloud auth list *",
+            "gcloud projects list *",
+            "az account list *",
+            "az account show *",
+            "kubectl get *",
+            "kubectl describe *",
+            "kubectl logs *",
+            "kubectl version *",
+            "helm list *",
+            "helm status *",
+            "helm version *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "swift build *",
+            "swift test *",
+            "zig build *",
+            "zig build test*",
+            "kotlinc *",
+            "scalac *",
+            "javac *",
+            "javap *",
+            "clang *",
+            "jar *",
+            "sbt *",
+            "gradle *",
+            "bazel build *",
+            "bazel test *",
+            "bazel run *",
+            "mix *",
+            "lua *",
+            "ruby *",
+            "php *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "mkdir -p *",
+            "chmod +x *",
+            "dos2unix *",
+            "unix2dos *",
+            "ln -s *"
+          ]
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": [
+            "for *",
+            "while *",
+            "do *",
+            "done *",
+            "if *",
+            "then *",
+            "else *",
+            "elif *",
+            "fi *",
+            "case *",
+            "esac *",
+            "in *",
+            "function *",
+            "select *",
+            "until *",
+            "{ *",
+            "} *",
+            "[[ *",
+            "]] *"
+          ]
+        },
+        "action": "ask"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": "/^find(?!.*(-delete|-exec|-execdir)).*$/"
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": "/^(echo|ls|pwd|date|whoami|id|uname)\\s.*[&|;].*\\s*(echo|ls|pwd|date|whoami|id|uname)($|\\s.*)/"
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": "/^(cat|grep|head|tail|less|more|find)\\s.*\\|\\s*(grep|head|tail|less|more|wc|sort|uniq)($|\\s.*)/"
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": "/^rm\\s+.*(-[rf].*-[rf]|-[rf]{2,}|--recursive.*--force|--force.*--recursive).*$/"
+        },
+        "action": "ask"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": "/^find.*(-delete|-exec|-execdir).*$/"
+        },
+        "action": "ask"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": "/^(ls|cat|grep|head|tail|file|stat)\\s+[^/]*$/"
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": "/^(?!.*(rm|mv|cp|chmod|chown|sudo|su|dd)\\b).*/dev/(null|zero|stdout|stderr|stdin).*$/"
+        },
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "matches": {
+          "cmd": "/(^|\\s)(\\/(?!dev\\/(null|zero|stdout|stderr|stdin))[^\\s]*|\\.\\.\\/)(?![^\\s]*\\.(log|txt|md|json|yml|yaml)$)/"
+        },
+        "action": "ask"
+      },
+      {
+        "tool": "Bash",
+        "action": "ask"
+      },
+      {
+        "tool": "Glob",
+        "action": "allow"
+      },
+      {
+        "tool": "Task",
+        "action": "allow"
+      },
+      {
+        "tool": "finder",
+        "action": "allow"
+      },
+      {
+        "tool": "get_diagnostics",
+        "action": "allow"
+      },
+      {
+        "tool": "Bash",
+        "action": "allow"
+      },
+      {
+        "tool": "oracle",
+        "action": "allow"
+      },
+      {
+        "tool": "mermaid",
+        "action": "allow"
+      },
+      {
+        "tool": "todo_read",
+        "action": "allow"
+      },
+      {
+        "tool": "todo_write",
+        "action": "allow"
+      },
+      {
+        "tool": "read_web_page",
+        "action": "allow"
+      },
+      {
+        "tool": "create_file",
+        "action": "allow"
+      },
+      {
+        "tool": "glob",
+        "action": "allow"
+      },
+      {
+        "tool": "Glob",
+        "action": "allow"
+      },
+      {
+        "tool": "undo_edit",
+        "action": "allow"
+      },
+      {
+        "tool": "Read",
+        "action": "allow"
+      },
+      {
+        "tool": "edit_file",
+        "action": "allow"
+      },
+      {
+        "tool": "delete_file",
+        "action": "allow"
+      },
+      {
+        "tool": "format_file",
+        "action": "allow"
+      },
+      {
+        "tool": "web_search",
+        "action": "allow"
+      },
+      {
+        "tool": "Grep",
+        "action": "allow"
+      },
+      {
+        "tool": "search_documents",
+        "action": "allow"
+      },
+      {
+        "tool": "get_document",
+        "action": "allow"
+      },
+      {
+        "tool": "Check",
+        "action": "allow"
+      },
+      {
+        "tool": "code_review",
+        "action": "allow"
+      },
+      {
+        "tool": "kraken",
+        "action": "allow"
+      },
+      {
+        "tool": "look_at",
+        "action": "allow"
+      },
+      {
+        "tool": "librarian",
+        "action": "allow"
+      },
+      {
+        "tool": "bookkeeper",
+        "action": "allow"
+      },
+      {
+        "tool": "read_thread",
+        "action": "allow"
+      },
+      {
+        "tool": "find_thread",
+        "action": "allow"
+      },
+      {
+        "tool": "read_artifact",
+        "action": "allow"
+      },
+      {
+        "tool": "edit_artifact",
+        "action": "allow"
+      },
+      {
+        "tool": "read_plan",
+        "action": "allow"
+      },
+      {
+        "tool": "edit_plan",
+        "action": "allow"
+      },
+      {
+        "tool": "skill",
+        "action": "allow"
+      }
+    ],
+    "sync.gist": "9402a3adf7ce68171821b19f4f25b1d9"
 }

--- a/app_modified/.config/Void/User/settings.json
+++ b/app_modified/.config/Void/User/settings.json
@@ -285,10 +285,10 @@
     "atlascode.jira.enabled": true,
     "atlascode.bitbucket.enabled": true,
     "chat.mcp.discovery.enabled": true,
+    "git.autofetch": true,
     "git.blame.editorDecoration.enabled": true,
     "gitlens.ai.model": "vscode",
     "files.autoSave": "afterDelay",
-    "git.autofetch": true,
     "rubyLsp.formatter": "auto",
     "rubyLsp.featureFlags": {
       "fullTestDiscovery": false

--- a/app_modified/.config/Void/User/settings.json
+++ b/app_modified/.config/Void/User/settings.json
@@ -246,6 +246,8 @@
     "remote.localPortHost": "allInterfaces",
     "remote.SSH.remoteServerListenOnSocket": true,
     "rubyTestExplorer.debugCommand": "bundle exec rdebug-ide",
+    "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
+    "rubyTestExplorer.logpanel": true,
     "solargraph.useBundler": true,
     "solargraph.transport": "external",
     "github.copilot.enable": {
@@ -296,7 +298,6 @@
     "rubyLsp.rubyVersionManager": {
       "identifier": "rvm"
     },
-    "rubyTestExplorer.rspecCommand": "rvm-auto-ruby -r bundler -e \"Bundler.require\" -e \"system(\\\"rspec \\\" + ARGV.join(\\\" \\\"))\" -- ",
     "testing.coverageToolbarEnabled": true,
     "sonarlint.testFilePattern": "**/test/**,**/tests/**,**/*test,**/spec/**",
     "sonarlint.analysisExcludesStandalone": "**/node_modules/**,**/vendor,**/__pycache__/**,**/site-packages/**,**/.void-editor/**",

--- a/app_modified/.config/Void/User/settings.json
+++ b/app_modified/.config/Void/User/settings.json
@@ -250,6 +250,10 @@
     "rubyTestExplorer.logpanel": true,
     "solargraph.useBundler": true,
     "solargraph.transport": "external",
+    "solargraph.externalServer": {
+      "host": "localhost",
+      "port": 7658
+    },
     "github.copilot.enable": {
       "*": true,
       "plaintext": false,
@@ -314,10 +318,6 @@
     "scss.lint.universalSelector": "warning",
     "custom-language-properties": {
       "scss.comments.lineComment": ""
-    },
-    "solargraph.externalServer": {
-      "host": "localhost",
-      "port": 7658
     },
     "amp.permissions": [
       {

--- a/app_modified/.config/Void/User/settings.json
+++ b/app_modified/.config/Void/User/settings.json
@@ -80,6 +80,10 @@
     "python.analysis.diagnosticMode": "openFilesOnly",
     "python.analysis.indexing": true,
     "python.trace.server": "verbose",
+    "python.locator": "native",
+    "python.defaultInterpreterPath": "/bin/python",
+    "python.useEnvironmentsExtension": true,
+    // "python-envs.defaultEnvManager": "ms-python.python:pyenv",
     "[python]": {
       "editor.formatOnSave": true,
       "editor.codeActionsOnSave": {
@@ -297,14 +301,10 @@
     "sonarlint.testFilePattern": "**/test/**,**/tests/**,**/*test,**/spec/**",
     "sonarlint.analysisExcludesStandalone": "**/node_modules/**,**/vendor,**/__pycache__/**,**/site-packages/**,**/.void-editor/**",
     "sonarlint.focusOnNewCode": true,
-    "python.locator": "native",
     "mesonbuild.linter.muon.enabled": true,
     "sonarlint.output.showVerboseLogs": true,
-    // "python.defaultInterpreterPath": "/bin/python",
-    // "python-envs.defaultEnvManager": "ms-python.python:pyenv",
     "telemetry.telemetryLevel": "all",
     "workbench.tree.enableStickyScroll": false,
-    "python.useEnvironmentsExtension": true,
     "atlascode.jira.lastCreateSiteAndProject": {
       "siteId": "0cf91bcd-95a2-4137-be0f-653eb2908f55",
       "projectKey": "LPSPRIG"
@@ -314,7 +314,6 @@
     "custom-language-properties": {
       "scss.comments.lineComment": ""
     },
-    "python.defaultInterpreterPath": "/bin/python",
     "solargraph.externalServer": {
       "host": "localhost",
       "port": 7658

--- a/app_modified/.config/Void/User/settings.json
+++ b/app_modified/.config/Void/User/settings.json
@@ -10,6 +10,7 @@
       ]
     },
     "window.titleBarStyle": "native",
+    "workbench.tree.enableStickyScroll": false,
     "workbench.colorTheme": "Default Dark Modern",
     "editor.fontFamily": "'JetBrainsMono Nerd Font Mono', 'JetBrainsMono Nerd Font', 'FiraCode Nerd Font Mono', 'Monoid Nerd Font Mono', 'Droid Sans Mono',  monospace, 'Droid Sans Fallback'",
     "terminal.integrated.fontFamily": "'JetBrainsMono Nerd Font', monospace",
@@ -309,7 +310,6 @@
     "sonarlint.analysisExcludesStandalone": "**/node_modules/**,**/vendor,**/__pycache__/**,**/site-packages/**,**/.void-editor/**",
     "sonarlint.focusOnNewCode": true,
     "sonarlint.output.showVerboseLogs": true,
-    "workbench.tree.enableStickyScroll": false,
     "atlascode.jira.lastCreateSiteAndProject": {
       "siteId": "0cf91bcd-95a2-4137-be0f-653eb2908f55",
       "projectKey": "LPSPRIG"

--- a/app_modified/.config/Void/User/settings.json
+++ b/app_modified/.config/Void/User/settings.json
@@ -259,7 +259,6 @@
     "gopls": {
       "ui.semanticTokens": true
     },
-    "mesonbuild.downloadLanguageServer": true,
     "cmake.pinnedCommands": [
       "workbench.action.tasks.configureTaskRunner",
       "workbench.action.tasks.runTask"
@@ -291,6 +290,8 @@
     "git.blame.editorDecoration.enabled": true,
     "gitlens.ai.model": "vscode",
     "files.autoSave": "afterDelay",
+    "mesonbuild.downloadLanguageServer": true,
+    "mesonbuild.linter.muon.enabled": true,
     "rubyLsp.formatter": "auto",
     "rubyLsp.featureFlags": {
       "fullTestDiscovery": false
@@ -302,7 +303,6 @@
     "sonarlint.testFilePattern": "**/test/**,**/tests/**,**/*test,**/spec/**",
     "sonarlint.analysisExcludesStandalone": "**/node_modules/**,**/vendor,**/__pycache__/**,**/site-packages/**,**/.void-editor/**",
     "sonarlint.focusOnNewCode": true,
-    "mesonbuild.linter.muon.enabled": true,
     "sonarlint.output.showVerboseLogs": true,
     "telemetry.telemetryLevel": "all",
     "workbench.tree.enableStickyScroll": false,

--- a/app_modified/.config/Void/User/settings.json
+++ b/app_modified/.config/Void/User/settings.json
@@ -16,6 +16,7 @@
     "terminal.integrated.allowChords": false,
     "editor.fontLigatures": "'cv02', 'cv04', 'cv05', 'cv07', 'cv08', 'cv11', 'cv14', 'cv99', 'ss19', 'zero', 'calt', 'ss04', 'ss08', 'ss09', 'cv23'",
     "window.zoomLevel": 1,
+    "telemetry.telemetryLevel": "all",
     "redhat.telemetry.enabled": true,
     "sonarlint.disableTelemetry": true,
     "git.openRepositoryInParentFolders": "always",
@@ -308,7 +309,6 @@
     "sonarlint.analysisExcludesStandalone": "**/node_modules/**,**/vendor,**/__pycache__/**,**/site-packages/**,**/.void-editor/**",
     "sonarlint.focusOnNewCode": true,
     "sonarlint.output.showVerboseLogs": true,
-    "telemetry.telemetryLevel": "all",
     "workbench.tree.enableStickyScroll": false,
     "atlascode.jira.lastCreateSiteAndProject": {
       "siteId": "0cf91bcd-95a2-4137-be0f-653eb2908f55",


### PR DESCRIPTION
- **Void: Consolidate python settings section**
- **vscode: Consolidate python settings section & merge w/Void config**
- **vscode: Enable `ms-python.vscode-python-envs` proposed APIs**
- **vscode: Disable sonarlint telemetry**
- **vscode: Configure isort lines after import to match Ruff**
- **vscode: Remove atlassian.atlascode yaml.schemas (b/c it always overwrites `$HOME` abs path)**
- **vscode: Merge `amp.permissions` settings from Void & Configure `sync.gist`**
- **vscode: Merge `atlascode` ext settings from Void**
- **vscode: Disable BitBucket for atlascode ext**
- **vscode: Enable MCP server discovery (e.g. from Claude)**
- **Void: Reorder nearby `git.*` settings**
- **vscode: Merge `git{,lens}.*` settings from Void**
- **vscode: Merge `files.autoSave`: "afterDelay" setting from Void**
- **vscode: Merge `rubyLsp.*` settings from Void**
- **Void: Consolidate `rubyTestExplorer` settings section & merge w/vscode config**
- **vscode: Consolidate `rubyTestExplorer` settings section & merge w/Void config**
- **Void: Consolidate `mesonbuild` settings section & merge w/vscode config**
- **vscode: Consolidate `mesonbuild` settings section & merge w/Void config**
- **Void: Consolidate `solargraph` settings section & merge w/vscode config**
- **vscode: Consolidate `solargraph` settings section & merge w/Void config**
- **vscode: Merge `testing.coverageToolbarEnabled: "true"` from Void**
- **Void: Consolidate `telemetry` settings section**
- **vscode: Consolidate `telemetry` settings section & turn down `telemetryLevel` to `"error"`**
- **vscode: Merge `sonarlint` settings from Void**
- **Void: Consolidate `workbench` settings section**
- **vscode: Consolidate `workbench` settings section & Merge with Void**
- **vscode: Merge `scss` settings from Void**
